### PR TITLE
Add tone information to case vibes

### DIFF
--- a/lib/caseVibes.ts
+++ b/lib/caseVibes.ts
@@ -1,6 +1,10 @@
-﻿export type CaseVibe = {
+
+import type { BadgeTone } from "@/lib/badge";
+
+export type CaseVibe = {
   emoji: string;
   label: string;
+  tone: BadgeTone;
   surface: string;
   shadow: string;
   accent: string;
@@ -14,6 +18,7 @@ const palette: CaseVibe[] = [
   {
     emoji: "🎯",
     label: "A/B",
+    tone: "rose",
     surface:
       "bg-gradient-to-br from-rose-200 via-pink-100 to-amber-100 dark:from-rose-600/45 dark:via-pink-500/35 dark:to-amber-400/30",
     shadow: "shadow-[0_28px_52px_-26px_rgba(244,114,182,0.6)]",
@@ -28,6 +33,7 @@ const palette: CaseVibe[] = [
   {
     emoji: "🚚",
     label: "Ops",
+    tone: "emerald",
     surface:
       "bg-gradient-to-br from-emerald-100 via-sky-50/80 to-lime-100 dark:from-emerald-500/25 dark:via-sky-500/18 dark:to-lime-500/18",
     shadow: "shadow-[0_24px_48px_-24px_rgba(16,185,129,0.38)]",
@@ -42,6 +48,7 @@ const palette: CaseVibe[] = [
   {
     emoji: "🧠",
     label: "Modeling",
+    tone: "purple",
     surface:
       "bg-gradient-to-br from-violet-100 via-indigo-50/75 to-sky-100 dark:from-violet-500/25 dark:via-indigo-500/18 dark:to-sky-500/16",
     shadow: "shadow-[0_24px_48px_-24px_rgba(129,140,248,0.36)]",
@@ -56,6 +63,7 @@ const palette: CaseVibe[] = [
   {
     emoji: "🤖",
     label: "AI",
+    tone: "slate",
     surface:
       "bg-gradient-to-br from-slate-100 via-indigo-50/80 to-sky-100 dark:from-slate-200/28 dark:via-slate-300/20 dark:to-indigo-400/22",
     shadow: "shadow-[0_26px_52px_-24px_rgba(148,163,184,0.45)]",
@@ -70,6 +78,7 @@ const palette: CaseVibe[] = [
   {
     emoji: "🛠️",
     label: "Automation",
+    tone: "amber",
     surface:
       "bg-gradient-to-br from-amber-100 via-orange-50/75 to-lime-100 dark:from-amber-500/25 dark:via-orange-500/18 dark:to-lime-500/18",
     shadow: "shadow-[0_24px_48px_-24px_rgba(251,191,36,0.38)]",


### PR DESCRIPTION
## Summary
- include a tone property on each case vibe and export it in the type definition
- use the badge tone type to keep case and service badge usage aligned

## Testing
- npm run build *(fails: missing dependency `clsx` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d52e2da9fc83299ec41899c9c6cd73