### PR TITLE
Implement case carousel and UX improvements

### DIFF
--- a/app/cases/[slug]/page.tsx
+++ b/app/cases/[slug]/page.tsx
@@ -13,7 +13,6 @@ import CaseReadingProgress from '@/components/CaseReadingProgress';
 import CaseCTA from '@/components/CaseCTA';
 import CaseSectionIsland from '@/components/CaseSectionIsland';
 import Container from "@/components/Container";
-import BackButton from '@/components/BackButton';
 
 const prettyCodeOptions = {
   theme: { light: "github-light", dark: "github-dark" },
@@ -101,9 +100,6 @@ export default async function CasePage({
 
       <section className="py-10 sm:py-16">
         <Container>
-          <div className="mb-6 flex justify-start">
-            <BackButton caseId={params.slug} />
-          </div>
           <CaseHero
             slug={params.slug}
             title={frontmatter.title}
@@ -118,38 +114,38 @@ export default async function CasePage({
       </section>
 
       <section className="pb-16 sm:pb-20">
-        <div className="mx-auto w-full max-w-[68rem] px-5 sm:px-6 lg:px-8">
-          <div className="space-y-8 sm:space-y-10">
-          {intro.length > 0 && (
-            <CaseSectionIsland tone="neutral">
-              <div className="case-article">
-                <div className="mx-auto w-full space-y-4 md:max-w-[72ch]">{intro}</div>
-              </div>
-            </CaseSectionIsland>
-          )}
-
-          {sections.map((section, index) => {
-            const tone = toneCycle[index % toneCycle.length];
-            const clonedHeading = React.cloneElement(section.heading, {
-              className:
-                'text-2xl font-semibold leading-tight text-slate-900 tracking-tight dark:text-white',
-            });
-
-            return (
-              <CaseSectionIsland tone={tone} key={section.heading.props.id ?? index}>
-                <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  {clonedHeading}
-                </header>
+        <Container>
+          <div className="mx-auto w-full max-w-[62rem] space-y-8 sm:space-y-10">
+            {intro.length > 0 && (
+              <CaseSectionIsland tone="neutral" className="mx-auto w-full">
                 <div className="case-article">
-                  <div className="mx-auto w-full space-y-4 md:max-w-[72ch]">{section.body}</div>
+                  <div className="mx-auto w-full max-w-[62rem] space-y-4">{intro}</div>
                 </div>
               </CaseSectionIsland>
-            );
-          })}
-        </div>
-      </div>
+            )}
 
-        <CaseCTA result={frontmatter?.result} />
+            {sections.map((section, index) => {
+              const tone = toneCycle[index % toneCycle.length];
+              const clonedHeading = React.cloneElement(section.heading, {
+                className:
+                  'text-2xl font-semibold leading-tight text-slate-900 tracking-tight dark:text-white',
+              });
+
+              return (
+                <CaseSectionIsland tone={tone} key={section.heading.props.id ?? index} className="mx-auto w-full">
+                  <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    {clonedHeading}
+                  </header>
+                  <div className="case-article">
+                    <div className="mx-auto w-full max-w-[62rem] space-y-4">{section.body}</div>
+                  </div>
+                </CaseSectionIsland>
+              );
+            })}
+          </div>
+
+          <CaseCTA result={frontmatter?.result} />
+        </Container>
       </section>
     </>
   );

--- a/app/cases/[slug]/page.tsx
+++ b/app/cases/[slug]/page.tsx
@@ -1,7 +1,6 @@
 ﻿import React from "react";
 
 import { getCaseSlugs, readCaseBySlug } from "@/lib/mdx";
-import Container from "@/components/Container";
 import type { Metadata } from "next";
 import { compileMDX } from "next-mdx-remote/rsc";
 
@@ -13,6 +12,7 @@ import CaseHero from '@/components/CaseHero';
 import CaseReadingProgress from '@/components/CaseReadingProgress';
 import CaseCTA from '@/components/CaseCTA';
 import CaseSectionIsland from '@/components/CaseSectionIsland';
+import Container from "@/components/Container";
 import BackButton from '@/components/BackButton';
 
 const prettyCodeOptions = {
@@ -99,10 +99,10 @@ export default async function CasePage({
     <>
       <CaseReadingProgress />
 
-      <div className="py-10 sm:py-16">
+      <section className="py-10 sm:py-16">
         <Container>
           <div className="mb-6 flex justify-start">
-            <BackButton />
+            <BackButton caseId={params.slug} />
           </div>
           <CaseHero
             slug={params.slug}
@@ -115,15 +115,15 @@ export default async function CasePage({
             links={frontmatter.links}
           />
         </Container>
-      </div>
+      </section>
 
-      <Container className="pb-14 sm:pb-20">
-        <div className="mx-auto w-full px-4 sm:px-6 max-w-3xl lg:max-w-4xl xl:max-w-5xl">
+      <section className="pb-16 sm:pb-20">
+        <div className="mx-auto w-full max-w-[68rem] px-5 sm:px-6 lg:px-8">
           <div className="space-y-8 sm:space-y-10">
           {intro.length > 0 && (
             <CaseSectionIsland tone="neutral">
               <div className="case-article">
-                <div className="mx-auto max-w-[72ch] space-y-4">{intro}</div>
+                <div className="mx-auto w-full space-y-4 md:max-w-[72ch]">{intro}</div>
               </div>
             </CaseSectionIsland>
           )}
@@ -141,7 +141,7 @@ export default async function CasePage({
                   {clonedHeading}
                 </header>
                 <div className="case-article">
-                  <div className="mx-auto max-w-[72ch] space-y-4">{section.body}</div>
+                  <div className="mx-auto w-full space-y-4 md:max-w-[72ch]">{section.body}</div>
                 </div>
               </CaseSectionIsland>
             );
@@ -150,7 +150,7 @@ export default async function CasePage({
       </div>
 
         <CaseCTA result={frontmatter?.result} />
-      </Container>
+      </section>
     </>
   );
 }

--- a/app/cases/[slug]/page.tsx
+++ b/app/cases/[slug]/page.tsx
@@ -100,16 +100,18 @@ export default async function CasePage({
 
       <section className="py-10 sm:py-16">
         <Container>
-          <CaseHero
-            slug={params.slug}
-            title={frontmatter.title}
-            summary={frontmatter.summary}
-            role={frontmatter.role}
-            duration={frontmatter.duration}
-            status={frontmatter.status}
-            tags={frontmatter.tags}
-            links={frontmatter.links}
-          />
+          <div className="mx-auto w-full max-w-[62rem]">
+            <CaseHero
+              slug={params.slug}
+              title={frontmatter.title}
+              summary={frontmatter.summary}
+              role={frontmatter.role}
+              duration={frontmatter.duration}
+              status={frontmatter.status}
+              tags={frontmatter.tags}
+              links={frontmatter.links}
+            />
+          </div>
         </Container>
       </section>
 
@@ -142,9 +144,8 @@ export default async function CasePage({
                 </CaseSectionIsland>
               );
             })}
+            <CaseCTA result={frontmatter?.result} />
           </div>
-
-          <CaseCTA result={frontmatter?.result} />
         </Container>
       </section>
     </>

--- a/app/cases/layout.tsx
+++ b/app/cases/layout.tsx
@@ -1,10 +1,16 @@
 'use client';
+
+import { useParams } from 'next/navigation';
+
 import Nav from '@/components/Nav';
 
 export default function CasesLayout({ children }: { children: React.ReactNode }) {
+  const params = useParams<{ slug?: string }>();
+  const slug = typeof params?.slug === 'string' ? params.slug : undefined;
+
   return (
     <div className="flex min-h-screen flex-col">
-      <Nav backToCases />
+      <Nav backToCases caseId={slug} />
       <main className="flex-1">{children}</main>
     </div>
   );

--- a/app/cases/layout.tsx
+++ b/app/cases/layout.tsx
@@ -1,16 +1,11 @@
 'use client';
 import Nav from '@/components/Nav';
-import Container from '@/components/Container';
 
 export default function CasesLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-screen flex-col">
       <Nav backToCases />
-      <main className="flex-1">
-        <Container className="py-10">
-          <article className="prose prose-zinc dark:prose-invert max-w-3xl">{children}</article>
-        </Container>
-      </main>
+      <main className="flex-1">{children}</main>
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -571,6 +571,35 @@
   position: relative;
 }
 
+.case-card__cta--accent {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.98), rgba(14, 165, 233, 0.95));
+  color: #061023 !important;
+  border-color: transparent;
+  box-shadow: 0 24px 48px -28px rgba(37, 99, 235, 0.45);
+}
+
+.case-card__cta--accent:hover {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.98), rgba(34, 211, 238, 0.95));
+}
+
+.case-card__cta--accent:focus-visible {
+  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.35), 0 24px 48px -28px rgba(37, 99, 235, 0.55);
+}
+
+.dark .case-card__cta--accent {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(56, 189, 248, 0.88));
+  color: #020817 !important;
+  box-shadow: 0 26px 52px -30px rgba(14, 165, 233, 0.6);
+}
+
+.dark .case-card__cta--accent:hover {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.92), rgba(45, 212, 191, 0.9));
+}
+
+.dark .case-card__cta--accent:focus-visible {
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.4), 0 26px 52px -30px rgba(14, 165, 233, 0.65);
+}
+
 .case-card__cta--primary {
   background: linear-gradient(135deg, rgba(244, 114, 182, 0.96), rgba(192, 132, 252, 0.96));
   color: #0f172a !important;

--- a/app/globals.css
+++ b/app/globals.css
@@ -534,6 +534,17 @@
   background: linear-gradient(180deg, rgba(8, 10, 18, 0) 38%, rgba(8, 10, 18, 0.48) 100%);
 }
 
+.case-card__result {
+  border: 1px solid color-mix(in oklab, var(--result-border) 60%, white 40%);
+  background: color-mix(in oklab, white 78%, var(--result-bg) 22%);
+  color: color-mix(in oklab, rgb(15 23 42) 72%, var(--result-border) 28%);
+  box-shadow: 0 22px 48px -30px rgba(15, 23, 42, 0.25);
+}
+
+.case-card__result strong {
+  color: color-mix(in oklab, rgb(15 23 42) 55%, var(--result-border) 45%);
+}
+
 .dark .case-card__title {
   color: #eef0ff;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
@@ -546,7 +557,52 @@
 
 .dark .case-card__result {
   color: #f6f7ff;
-  background-color: rgba(46, 55, 83, 0.55);
+  background: linear-gradient(180deg, rgba(29, 36, 52, 0.52) 0%, rgba(12, 19, 33, 0.78) 100%);
   border-color: rgba(148, 163, 184, 0.35);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18), 0 20px 36px -28px rgba(15, 23, 42, 0.65);
+}
+
+.case-card__cta {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.case-card__cta--secondary {
+  position: relative;
+}
+
+.dark .case-card__cta--secondary {
+  background: color-mix(in oklab, white 88%, rgb(15 23 42) 12%);
+  color: rgb(15 23 42);
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow: 0 20px 40px -28px rgba(15, 23, 42, 0.75);
+}
+
+.dark .case-card__cta--secondary:hover {
+  background: color-mix(in oklab, white 92%, rgb(15 23 42) 8%);
+}
+
+.dark .case-card__cta--secondary:focus-visible {
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.35), 0 18px 36px -26px rgba(15, 23, 42, 0.72);
+}
+
+.dark .case-card__cta--accent {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.98), rgba(56, 189, 248, 0.92));
+  color: rgb(8 47 73);
+  border-color: transparent;
+  box-shadow: 0 24px 46px -28px rgba(59, 130, 246, 0.9);
+}
+
+.dark .case-card__cta--accent:hover {
+  background: linear-gradient(135deg, rgba(147, 197, 253, 0.98), rgba(96, 165, 250, 0.92));
+}
+
+.dark .case-card__cta--primary {
+  background: linear-gradient(135deg, rgba(244, 114, 182, 0.95), rgba(192, 132, 252, 0.95));
+  color: rgb(15 23 42);
+  box-shadow: 0 28px 52px -30px rgba(192, 132, 252, 0.85);
+}
+
+.dark .case-card__cta--primary:hover {
+  background: linear-gradient(135deg, rgba(249, 168, 212, 0.98), rgba(221, 214, 254, 0.95));
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -571,38 +571,31 @@
   position: relative;
 }
 
-.dark .case-card__cta--secondary {
-  background: color-mix(in oklab, white 88%, rgb(15 23 42) 12%);
-  color: rgb(15 23 42);
-  border-color: rgba(255, 255, 255, 0.16);
-  box-shadow: 0 20px 40px -28px rgba(15, 23, 42, 0.75);
-}
-
-.dark .case-card__cta--secondary:hover {
-  background: color-mix(in oklab, white 92%, rgb(15 23 42) 8%);
-}
-
-.dark .case-card__cta--secondary:focus-visible {
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.35), 0 18px 36px -26px rgba(15, 23, 42, 0.72);
-}
-
-.dark .case-card__cta--accent {
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.98), rgba(56, 189, 248, 0.92));
-  color: rgb(8 47 73);
+.case-card__cta--primary {
+  background: linear-gradient(135deg, rgba(244, 114, 182, 0.96), rgba(192, 132, 252, 0.96));
+  color: #0f172a !important;
   border-color: transparent;
-  box-shadow: 0 24px 46px -28px rgba(59, 130, 246, 0.9);
+  box-shadow: 0 26px 52px -28px rgba(192, 132, 252, 0.45);
 }
 
-.dark .case-card__cta--accent:hover {
-  background: linear-gradient(135deg, rgba(147, 197, 253, 0.98), rgba(96, 165, 250, 0.92));
+.case-card__cta--primary:hover {
+  background: linear-gradient(135deg, rgba(249, 168, 212, 0.98), rgba(221, 214, 254, 0.96));
+}
+
+.case-card__cta--primary:focus-visible {
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.4), 0 26px 52px -28px rgba(192, 132, 252, 0.5);
 }
 
 .dark .case-card__cta--primary {
-  background: linear-gradient(135deg, rgba(244, 114, 182, 0.95), rgba(192, 132, 252, 0.95));
-  color: rgb(15 23 42);
-  box-shadow: 0 28px 52px -30px rgba(192, 132, 252, 0.85);
+  background: linear-gradient(135deg, rgba(244, 114, 182, 0.9), rgba(168, 85, 247, 0.92));
+  color: #0b1120 !important;
+  box-shadow: 0 28px 54px -30px rgba(168, 85, 247, 0.65);
 }
 
 .dark .case-card__cta--primary:hover {
-  background: linear-gradient(135deg, rgba(249, 168, 212, 0.98), rgba(221, 214, 254, 0.95));
+  background: linear-gradient(135deg, rgba(249, 168, 212, 0.94), rgba(196, 181, 253, 0.94));
+}
+
+.dark .case-card__cta--primary:focus-visible {
+  box-shadow: 0 0 0 1px rgba(226, 232, 240, 0.45), 0 28px 54px -30px rgba(168, 85, 247, 0.7);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -456,3 +456,93 @@
     animation: none;
   }
 }
+
+/* ---------- Cases carousel ---------- */
+.case-carousel {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(78%, calc(100% - 3.5rem));
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0.5rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-padding-inline: 1.25rem;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+.case-carousel::-webkit-scrollbar {
+  display: none;
+}
+
+.case-carousel > li {
+  scroll-snap-align: start;
+}
+
+@media (min-width: 640px) {
+  .case-carousel {
+    grid-auto-columns: minmax(65%, calc(100% - 4rem));
+    gap: 1rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .case-carousel {
+    grid-auto-flow: row;
+    grid-auto-columns: initial;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.5rem;
+    overflow: visible;
+    scroll-snap-type: none;
+    scroll-padding-inline: 0;
+    padding-bottom: 0;
+  }
+
+  .case-carousel > li {
+    scroll-snap-align: none;
+  }
+}
+
+@media (min-width: 1024px) {
+  .case-carousel {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.case-card {
+  position: relative;
+  isolation: isolate;
+}
+
+.case-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.dark .case-card::after {
+  opacity: 1;
+  background: linear-gradient(180deg, rgba(8, 10, 18, 0) 38%, rgba(8, 10, 18, 0.48) 100%);
+}
+
+.dark .case-card__title {
+  color: #eef0ff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
+.dark .case-card__desc {
+  color: #d8dbf2;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.dark .case-card__result {
+  color: #f6f7ff;
+  background-color: rgba(46, 55, 83, 0.55);
+  border-color: rgba(148, 163, 184, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -459,9 +459,13 @@
 
 /* ---------- Cases carousel ---------- */
 .case-carousel {
+  --snap-mobile-width: minmax(78%, calc(100% - 3.5rem));
+  --snap-sm-width: minmax(65%, calc(100% - 4rem));
+  --snap-md-columns: repeat(2, minmax(0, 1fr));
+  --snap-lg-columns: repeat(3, minmax(0, 1fr));
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: minmax(78%, calc(100% - 3.5rem));
+  grid-auto-columns: var(--snap-mobile-width);
   gap: 0.75rem;
   list-style: none;
   margin: 0;
@@ -483,7 +487,7 @@
 
 @media (min-width: 640px) {
   .case-carousel {
-    grid-auto-columns: minmax(65%, calc(100% - 4rem));
+    grid-auto-columns: var(--snap-sm-width);
     gap: 1rem;
   }
 }
@@ -492,7 +496,7 @@
   .case-carousel {
     grid-auto-flow: row;
     grid-auto-columns: initial;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: var(--snap-md-columns);
     gap: 1.5rem;
     overflow: visible;
     scroll-snap-type: none;
@@ -507,7 +511,7 @@
 
 @media (min-width: 1024px) {
   .case-carousel {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: var(--snap-lg-columns);
   }
 }
 

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -20,7 +20,7 @@ export default function BackButton({ caseId }: { caseId?: string }) {
           window.location.href = "/#cases";
         }
       }}
-      className="inline-flex items-center gap-1 text-sm font-medium text-slate-700 opacity-80 transition hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--accent))] dark:text-slate-200 md:-ml-2"
+      className="inline-flex items-center gap-1 text-sm font-medium text-slate-700 opacity-80 transition hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--accent))] dark:text-slate-200 md:-ml-4 lg:-ml-8 xl:-ml-10"
     >
       ← Назад
     </button>

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -20,7 +20,7 @@ export default function BackButton({ caseId }: { caseId?: string }) {
           window.location.href = "/#cases";
         }
       }}
-      className="inline-flex items-center gap-1 text-sm font-medium text-slate-700 opacity-80 transition hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--accent))] dark:text-slate-200"
+      className="inline-flex items-center gap-1 text-sm font-medium text-slate-700 opacity-80 transition hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--accent))] dark:text-slate-200 md:-ml-2"
     >
       ← Назад
     </button>

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -2,21 +2,25 @@
 
 import { useRouter } from "next/navigation";
 
-export default function BackButton() {
+import { sendEvent } from "@/lib/analytics";
+
+export default function BackButton({ caseId }: { caseId?: string }) {
   const router = useRouter();
 
   return (
     <button
       type="button"
+      data-qa={caseId ? `hero-back-${caseId}` : 'hero-back'}
       onClick={() => {
         if (typeof window === "undefined") return;
+        sendEvent('hero_back_click', { case_id: caseId ?? null });
         if (window.history.length > 1) {
           router.back();
         } else {
           window.location.href = "/#cases";
         }
       }}
-      className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-900/10 px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800/40 dark:focus-visible:ring-offset-slate-900"
+      className="inline-flex min-h-[44px] items-center justify-center rounded-xl border border-slate-900/10 px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800/40 dark:focus-visible:ring-offset-slate-900"
     >
       ← Назад
     </button>

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -20,7 +20,7 @@ export default function BackButton({ caseId }: { caseId?: string }) {
           window.location.href = "/#cases";
         }
       }}
-      className="inline-flex items-center gap-1 text-sm font-medium text-slate-700 opacity-80 transition hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--accent))] dark:text-slate-200 md:-ml-4 lg:-ml-8 xl:-ml-10"
+      className="inline-flex items-center gap-1 text-sm font-medium text-slate-700 opacity-80 transition hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--accent))] dark:text-slate-200 md:-ml-8 lg:-ml-16 xl:-ml-24 2xl:-ml-32"
     >
       ← Назад
     </button>

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -20,7 +20,7 @@ export default function BackButton({ caseId }: { caseId?: string }) {
           window.location.href = "/#cases";
         }
       }}
-      className="inline-flex min-h-[44px] items-center justify-center rounded-xl border border-slate-900/10 px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800/40 dark:focus-visible:ring-offset-slate-900"
+      className="inline-flex items-center gap-1 text-sm font-medium text-slate-700 opacity-80 transition hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--accent))] dark:text-slate-200"
     >
       ← Назад
     </button>

--- a/components/BackgroundToggle.tsx
+++ b/components/BackgroundToggle.tsx
@@ -1,5 +1,7 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ButtonHTMLAttributes } from 'react';
+
+import clsx from '@/lib/clsx';
 
 const KEY = 'bg-mode'; // 'dynamic' | 'static'
 
@@ -8,7 +10,11 @@ function prefersReduced() {
   return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
 }
 
-export default function BackgroundToggle() {
+type BackgroundToggleProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  className?: string;
+};
+
+export default function BackgroundToggle({ className = '', ...rest }: BackgroundToggleProps) {
   const [mode, setMode] = useState<'dynamic' | 'static'>('dynamic');
 
   useEffect(() => {
@@ -29,8 +35,12 @@ export default function BackgroundToggle() {
     <button
       type="button"
       onClick={toggle}
-      className="text-sm px-3 py-1.5 rounded-xl border bg-background/60 hover:bg-background/80"
+      className={clsx(
+        'text-sm font-medium opacity-80 transition hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--accent))]',
+        className
+      )}
       title="Переключить фон"
+      {...rest}
     >
       Фон: {mode === 'dynamic' ? 'динамический' : 'статичный'}
     </button>

--- a/components/BriefForm.tsx
+++ b/components/BriefForm.tsx
@@ -194,7 +194,8 @@ export default function BriefForm({ defaultSource }: { defaultSource?: string })
         <button
           type="submit"
           disabled={loading}
-          className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-60"
+          className="rounded bg-blue-600 px-4 py-2 text-white transition disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400"
+          data-qa="brief-submit"
         >
           {loading ? 'Отправка…' : 'Отправить'}
         </button>

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -9,9 +9,11 @@ type Props = {
   className?: string;
   children: React.ReactNode;
   target?: string; // важно для внешних ссылок
-  rel?: string;    // важно для внешних ссылок
+  rel?: string; // важно для внешних ссылок
   onClick?: React.MouseEventHandler<HTMLAnchorElement | HTMLButtonElement>;
-} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+} &
+  React.ButtonHTMLAttributes<HTMLButtonElement> &
+  React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 export default function Button({
   variant = "primary",
@@ -42,15 +44,30 @@ export default function Button({
   const cls = `${base} ${styles} ${className}`.trim();
 
   if (href) {
+    const { type: _buttonType, ...anchorRest } = rest as React.AnchorHTMLAttributes<HTMLAnchorElement>;
     return (
-      <Link href={href} className={cls} target={target} rel={rel} onClick={onClick}>
+      <Link
+        href={href}
+        className={cls}
+        target={target}
+        rel={rel}
+        onClick={onClick as React.MouseEventHandler<HTMLAnchorElement>}
+        {...anchorRest}
+      >
         {children}
       </Link>
     );
   }
 
+  const { type, ...buttonRest } = rest;
+
   return (
-    <button className={cls} onClick={onClick} {...rest}>
+    <button
+      type={type ?? 'button'}
+      className={cls}
+      onClick={onClick as React.MouseEventHandler<HTMLButtonElement>}
+      {...buttonRest}
+    >
       {children}
     </button>
   );

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-export type CardVariant = "default" | "soft";
+export type CardVariant = "default" | "soft" | "plain";
 
 type CardProps = React.HTMLAttributes<HTMLDivElement> & {
   variant?: CardVariant;
@@ -9,10 +9,22 @@ type CardProps = React.HTMLAttributes<HTMLDivElement> & {
 export default function Card({ className = "", variant = "soft", ...rest }: CardProps) {
   const base =
     "rounded-2xl border border-slate-900/10 shadow-sm transition-shadow md:hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 p-4 sm:p-5 md:p-6 overflow-hidden";
-  const look =
-    variant === "soft"
-      ? "bg-gradient-to-br from-slate-50 to-white dark:from-slate-900/40 dark:to-slate-900/20"
-      : "bg-white dark:bg-slate-900/30";
+
+  let look = "";
+
+  switch (variant) {
+    case "soft":
+      look = "bg-gradient-to-br from-slate-50 to-white dark:from-slate-900/40 dark:to-slate-900/20";
+      break;
+    case "default":
+      look = "bg-white dark:bg-slate-900/30";
+      break;
+    case "plain":
+      look = "";
+      break;
+    default:
+      look = "bg-white dark:bg-slate-900/30";
+  }
 
   return <div className={`${base} ${look} ${className}`} {...rest} />;
 }

--- a/components/CaseCTA.tsx
+++ b/components/CaseCTA.tsx
@@ -39,12 +39,14 @@ export default function CaseCTA({ result }: { result?: string }) {
               scroll={false}
               onClick={handleBrief}
               className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-slate-900 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-900/20 transition md:hover:-translate-y-0.5 md:hover:bg-slate-800 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+              data-qa="case-cta-brief"
             >
               Оставить заявку
             </Link>
             <Link
               href="/#cases"
               className="inline-flex min-h-[44px] items-center justify-center rounded-xl border border-slate-300/70 bg-white/60 px-6 py-3 text-sm font-semibold text-slate-900 shadow-sm transition md:hover:-translate-y-0.5 md:hover:bg-white/80 dark:border-white/15 dark:bg-white/10 dark:text-white dark:hover:bg-white/15"
+              data-qa="case-cta-more"
             >
               Посмотреть ещё проекты
             </Link>

--- a/components/CaseHero.tsx
+++ b/components/CaseHero.tsx
@@ -74,7 +74,7 @@ export default function CaseHero({
 
         {hasLinks ? (
           <div className="flex flex-wrap gap-3">
-            {links!.map(({ label, href }) => {
+            {links!.map(({ label, href }, linkIndex) => {
               const isExternal = /^https?:/i.test(href);
               return (
                 <Button
@@ -84,6 +84,7 @@ export default function CaseHero({
                   target={isExternal ? '_blank' : undefined}
                   rel={isExternal ? 'noopener noreferrer' : undefined}
                   className="min-h-[44px] px-5"
+                  data-qa={`case-link-${slug}-${linkIndex}`}
                 >
                   {label}
                 </Button>

--- a/components/CaseHero.tsx
+++ b/components/CaseHero.tsx
@@ -1,7 +1,10 @@
+'use client';
+
 import Button from '@/components/Button';
 import Card from '@/components/Card';
 import CaseMeta from '@/components/CaseMeta';
 import Badge from '@/components/primitives/Badge';
+import BackButton from '@/components/BackButton';
 import { getCaseVibe } from '@/lib/caseVibes';
 
 interface CaseLink {
@@ -43,6 +46,9 @@ export default function CaseHero({
         className={`pointer-events-none absolute -right-24 -top-28 h-60 w-60 rounded-full blur-3xl opacity-60 ${vibe.halo}`}
       />
       <div className="relative z-[1] flex flex-col gap-6">
+        <div className="self-start">
+          <BackButton caseId={slug} />
+        </div>
         <header className="flex flex-wrap items-start gap-4">
           <span
             aria-hidden

--- a/components/CaseHero.tsx
+++ b/components/CaseHero.tsx
@@ -4,7 +4,6 @@ import Button from '@/components/Button';
 import Card from '@/components/Card';
 import CaseMeta from '@/components/CaseMeta';
 import Badge from '@/components/primitives/Badge';
-import BackButton from '@/components/BackButton';
 import { getCaseVibe } from '@/lib/caseVibes';
 
 interface CaseLink {
@@ -46,9 +45,6 @@ export default function CaseHero({
         className={`pointer-events-none absolute -right-24 -top-28 h-60 w-60 rounded-full blur-3xl opacity-60 ${vibe.halo}`}
       />
       <div className="relative z-[1] flex flex-col gap-6">
-        <div className="self-start">
-          <BackButton caseId={slug} />
-        </div>
         <header className="flex flex-wrap items-start gap-4">
           <span
             aria-hidden

--- a/components/CaseSectionIsland.tsx
+++ b/components/CaseSectionIsland.tsx
@@ -10,22 +10,22 @@ type Props = {
 
 const toneClasses: Record<Tone, string> = {
   neutral:
-    'border-slate-200/60 bg-white/80 shadow-[0_18px_56px_-30px_rgba(15,23,42,0.4)] dark:border-white/12 dark:bg-slate-900/45',
+    'sm:border-slate-200/60 sm:bg-white/80 sm:shadow-[0_18px_56px_-30px_rgba(15,23,42,0.4)] dark:sm:border-white/12 dark:sm:bg-slate-900/45',
   cool:
-    'border-sky-200/60 bg-gradient-to-br from-sky-50/90 via-slate-50/70 to-transparent shadow-[0_26px_60px_-34px_rgba(56,189,248,0.45)] dark:border-sky-500/20 dark:from-slate-900/60 dark:via-slate-900/40 dark:to-slate-900/20',
+    'sm:border-sky-200/60 sm:bg-gradient-to-br sm:from-sky-50/90 sm:via-slate-50/70 sm:to-transparent sm:shadow-[0_26px_60px_-34px_rgba(56,189,248,0.45)] dark:sm:border-sky-500/20 dark:sm:from-slate-900/60 dark:sm:via-slate-900/40 dark:sm:to-slate-900/20',
   warm:
-    'border-amber-200/60 bg-gradient-to-br from-amber-50/85 via-white/70 to-transparent shadow-[0_26px_60px_-34px_rgba(251,191,36,0.4)] dark:border-amber-500/20 dark:from-slate-900/60 dark:via-slate-900/40 dark:to-slate-900/20',
+    'sm:border-amber-200/60 sm:bg-gradient-to-br sm:from-amber-50/85 sm:via-white/70 sm:to-transparent sm:shadow-[0_26px_60px_-34px_rgba(251,191,36,0.4)] dark:sm:border-amber-500/20 dark:sm:from-slate-900/60 dark:sm:via-slate-900/40 dark:sm:to-slate-900/20',
   iris:
-    'border-indigo-200/60 bg-gradient-to-br from-indigo-50/90 via-slate-50/70 to-transparent shadow-[0_26px_60px_-34px_rgba(129,140,248,0.4)] dark:border-indigo-500/20 dark:from-slate-900/60 dark:via-slate-900/40 dark:to-slate-900/20',
+    'sm:border-indigo-200/60 sm:bg-gradient-to-br sm:from-indigo-50/90 sm:via-slate-50/70 sm:to-transparent sm:shadow-[0_26px_60px_-34px_rgba(129,140,248,0.4)] dark:sm:border-indigo-500/20 dark:sm:from-slate-900/60 dark:sm:via-slate-900/40 dark:sm:to-slate-900/20',
 };
 
 export default function CaseSectionIsland({ tone = 'neutral', className = '', children }: Props) {
-  const base = `relative overflow-hidden rounded-3xl border backdrop-blur-xl ${toneClasses[tone]} ${className}`.trim();
+  const base = `relative overflow-hidden rounded-none border-0 bg-transparent sm:rounded-3xl sm:border sm:bg-transparent sm:backdrop-blur-xl ${toneClasses[tone]} ${className}`.trim();
 
   return (
     <section className={base}>
-      <div className="absolute inset-0 bg-gradient-to-br from-white/20 via-transparent to-transparent dark:from-white/4" aria-hidden />
-      <div className="relative z-[1] flex flex-col gap-5 p-6 sm:p-8">{children}</div>
+      <div className="absolute inset-0 hidden bg-gradient-to-br from-white/20 via-transparent to-transparent dark:from-white/4 sm:block" aria-hidden />
+      <div className="relative z-[1] flex flex-col gap-5 px-0 py-6 sm:px-8 sm:py-8">{children}</div>
     </section>
   );
 }

--- a/components/Cases.tsx
+++ b/components/Cases.tsx
@@ -292,7 +292,7 @@ function CaseCard({ item, index }: CaseCardProps) {
         {item.result ? (
           <p
             id={`${cardId}-result`}
-            className="case-card__result rounded-xl border border-white/40 bg-white/70 p-4 text-sm font-medium text-slate-700 backdrop-blur dark:border-white/20 dark:bg-white/10 dark:text-slate-100"
+            className="case-card__result rounded-xl p-4 text-sm font-medium leading-6 backdrop-blur"
           >
             {item.result}
           </p>
@@ -338,7 +338,7 @@ function CaseCard({ item, index }: CaseCardProps) {
           <Button
             variant="accent"
             href={`/cases/${item.slug}`}
-            className="min-h-[44px] px-5"
+            className="case-card__cta case-card__cta--accent case-card__cta--primary min-h-[44px] px-5"
             data-qa={`cta-view-case-${item.slug}`}
             onClick={() => {
               trackClick({ action: 'cta_primary' });
@@ -347,22 +347,30 @@ function CaseCard({ item, index }: CaseCardProps) {
           >
             Смотреть кейс
           </Button>
-          {item.ctas?.map((cta, ctaIndex) => (
-            <Button
-              key={cta.label}
-              variant={cta.variant || 'secondary'}
-              href={cta.href}
-              target={cta.kind === 'external' ? '_blank' : undefined}
-              rel={cta.kind === 'external' ? 'noopener noreferrer' : undefined}
-              className="min-h-[44px] px-4"
-              data-qa={`cta-case-${item.slug}-${ctaIndex}-${toDataQa(cta.label)}`}
-              onClick={() => {
-                trackClick({ action: 'cta_secondary', label: cta.label, href: cta.href });
-              }}
-            >
-              {cta.label}
-            </Button>
-          ))}
+          {item.ctas?.map((cta, ctaIndex) => {
+            const variant = cta.variant || 'secondary';
+            const accentTone = variant === 'accent';
+
+            return (
+              <Button
+                key={cta.label}
+                variant={variant}
+                href={cta.href}
+                target={cta.kind === 'external' ? '_blank' : undefined}
+                rel={cta.kind === 'external' ? 'noopener noreferrer' : undefined}
+                className={clsx(
+                  'case-card__cta min-h-[44px] px-4',
+                  accentTone ? 'case-card__cta--accent' : 'case-card__cta--secondary'
+                )}
+                data-qa={`cta-case-${item.slug}-${ctaIndex}-${toDataQa(cta.label)}`}
+                onClick={() => {
+                  trackClick({ action: 'cta_secondary', label: cta.label, href: cta.href });
+                }}
+              >
+                {cta.label}
+              </Button>
+            );
+          })}
         </footer>
       </Card>
     </li>

--- a/components/Cases.tsx
+++ b/components/Cases.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import * as React from 'react';
-import { useRouter } from 'next/navigation';
 import clsx from 'clsx';
 
 import Container from '@/components/Container';
@@ -11,6 +10,7 @@ import Badge from '@/components/primitives/Badge';
 import MetricBadge from '@/components/primitives/MetricBadge';
 import { useCardAnalytics } from '@/components/hooks/useCardAnalytics';
 import { getCaseVibe } from '@/lib/caseVibes';
+import { sendEvent } from '@/lib/analytics';
 import type { BadgeTone } from '@/lib/badge';
 
 type Metric = {
@@ -157,7 +157,123 @@ const statusTone: Record<NonNullable<CaseItem['status']>, BadgeTone> = {
   ready: 'purple',
 };
 
+function toDataQa(value: string) {
+  const normalized = value
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9\u0400-\u04FF-]/g, '');
+
+  return normalized.length > 0 ? normalized : 'cta';
+}
+
 export default function Cases() {
+  const listRef = React.useRef<HTMLUListElement | null>(null);
+  const metricsRef = React.useRef({ item: 0, gap: 0 });
+  const rafRef = React.useRef<number>();
+  const [activeIndex, setActiveIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    const node = listRef.current;
+    if (!node || typeof window === 'undefined') {
+      return;
+    }
+
+    const computeMetrics = () => {
+      const firstItem = node.querySelector(':scope > li') as HTMLElement | null;
+      if (!firstItem) {
+        return;
+      }
+      const styles = window.getComputedStyle(node);
+      const gap = parseFloat(styles.columnGap || styles.gap || '0');
+      metricsRef.current = {
+        item: firstItem.getBoundingClientRect().width,
+        gap: Number.isFinite(gap) ? gap : 0,
+      };
+    };
+
+    computeMetrics();
+
+    const handleResize = () => computeMetrics();
+
+    if (!('ResizeObserver' in window)) {
+      window.addEventListener('resize', handleResize);
+      return () => {
+        window.removeEventListener('resize', handleResize);
+      };
+    }
+
+    const resizeObserver = new ResizeObserver(handleResize);
+    resizeObserver.observe(node);
+    node.querySelectorAll(':scope > li').forEach((child) => resizeObserver.observe(child));
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    return () => {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  const scrollToIndex = React.useCallback((nextIndex: number) => {
+    const node = listRef.current;
+    if (!node) return;
+    const { item, gap } = metricsRef.current;
+    if (!item) return;
+    const clamped = Math.max(0, Math.min(nextIndex, cases.length - 1));
+    const offset = clamped * (item + gap);
+    node.scrollTo({ left: offset, behavior: 'smooth' });
+  }, []);
+
+  const handleCarouselKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLUListElement>) => {
+      if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+        return;
+      }
+      event.preventDefault();
+      const delta = event.key === 'ArrowRight' ? 1 : -1;
+      scrollToIndex(activeIndex + delta);
+    },
+    [activeIndex, scrollToIndex]
+  );
+
+  const handleScroll = React.useCallback(() => {
+    if (typeof window === 'undefined') return;
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+    }
+    rafRef.current = window.requestAnimationFrame(() => {
+      const node = listRef.current;
+      if (!node) return;
+      const { item, gap } = metricsRef.current;
+      if (!item) return;
+      const rawIndex = node.scrollLeft / (item + gap || 1);
+      const nextIndex = Math.round(rawIndex);
+      const clamped = Math.max(0, Math.min(nextIndex, cases.length - 1));
+      setActiveIndex((prev) => (prev === clamped ? prev : clamped));
+    });
+  }, []);
+
+  const reportedIndexRef = React.useRef(0);
+  React.useEffect(() => {
+    if (activeIndex === reportedIndexRef.current) {
+      return;
+    }
+    const current = cases[activeIndex];
+    if (!current) {
+      return;
+    }
+    reportedIndexRef.current = activeIndex;
+    sendEvent('carousel_swipe', { case_id: current.slug, position: activeIndex });
+  }, [activeIndex]);
+
   return (
     <section id="cases" className="py-16 sm:py-24">
       <Container>
@@ -171,11 +287,33 @@ export default function Cases() {
           </p>
         </header>
 
-        <ul className="grid grid-cols-1 gap-3 sm:gap-4 md:grid-cols-2 md:gap-6 lg:grid-cols-3" role="list">
-          {cases.map((item, index) => (
-            <CaseCard key={item.slug} item={item} index={index} />
-          ))}
-        </ul>
+        <div role="group" aria-roledescription="carousel" aria-label="Кейсы">
+          <ul
+            ref={listRef}
+            className="case-carousel"
+            role="list"
+            tabIndex={0}
+            onKeyDown={handleCarouselKeyDown}
+            onScroll={handleScroll}
+          >
+            {cases.map((item, index) => (
+              <CaseCard key={item.slug} item={item} index={index} />
+            ))}
+          </ul>
+          <div className="mt-4 flex justify-center gap-2 md:hidden" aria-hidden="true">
+            {cases.map((caseItem, index) => (
+              <span
+                key={caseItem.slug}
+                className={clsx(
+                  'h-1.5 w-6 rounded-full transition-colors',
+                  activeIndex === index
+                    ? 'bg-white/80 shadow-[0_0_8px_rgba(0,0,0,0.25)] dark:bg-slate-100'
+                    : 'bg-slate-300/60 dark:bg-slate-600/60'
+                )}
+              />
+            ))}
+          </div>
+        </div>
       </Container>
     </section>
   );
@@ -187,7 +325,6 @@ type CaseCardProps = {
 };
 
 function CaseCard({ item, index }: CaseCardProps) {
-  const router = useRouter();
   const vibe = getCaseVibe(item.slug, index);
   const { ref, trackClick } = useCardAnalytics<HTMLLIElement>({
     id: item.slug,
@@ -195,35 +332,6 @@ function CaseCard({ item, index }: CaseCardProps) {
     index,
     payload: { title: item.title },
   });
-
-  React.useEffect(() => {
-    router.prefetch?.(`/cases/${item.slug}`);
-  }, [item.slug, router]);
-
-  const handleNavigate = React.useCallback(() => {
-    trackClick({ action: 'open' });
-    router.push(`/cases/${item.slug}`);
-  }, [item.slug, router, trackClick]);
-
-  const handleCardClick = React.useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
-      if ((event.target as HTMLElement).closest('[data-prevent-card]')) {
-        return;
-      }
-      handleNavigate();
-    },
-    [handleNavigate]
-  );
-
-  const handleKeyDown = React.useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === 'Enter' || event.key === ' ') {
-        event.preventDefault();
-        handleNavigate();
-      }
-    },
-    [handleNavigate]
-  );
 
   const tags = item.tags || [];
   const mobileMax = 3;
@@ -235,13 +343,13 @@ function CaseCard({ item, index }: CaseCardProps) {
   return (
     <li ref={ref} className="group/card list-none">
       <Card
-        role="link"
-        tabIndex={0}
         aria-labelledby={`${cardId}-title`}
         aria-describedby={item.result ? `${cardId}-result` : undefined}
-        className={`relative flex h-full flex-col gap-4 transition md:hover:-translate-y-1 md:hover:shadow-lg motion-reduce:md:hover:translate-y-0 ${vibe.surface} ${vibe.shadow}`}
-        onClick={handleCardClick}
-        onKeyDown={handleKeyDown}
+        className={clsx(
+          'case-card relative flex h-full flex-col gap-4 transition md:hover:-translate-y-1 md:hover:shadow-lg motion-reduce:md:hover:translate-y-0',
+          vibe.surface,
+          vibe.shadow
+        )}
       >
         <span
           aria-hidden
@@ -264,17 +372,17 @@ function CaseCard({ item, index }: CaseCardProps) {
         </header>
         <h3
           id={`${cardId}-title`}
-          className="mt-2 text-lg font-semibold leading-tight text-slate-900 line-clamp-2 md:mt-3 dark:text-white"
+          className="case-card__title mt-2 text-lg font-semibold leading-tight text-slate-900 line-clamp-2 md:mt-3 dark:text-white"
         >
           {item.title}
         </h3>
-        <p className="text-sm leading-6 text-slate-600 line-clamp-2 dark:text-slate-300">
+        <p className="case-card__desc text-sm leading-6 text-slate-600 line-clamp-2 dark:text-slate-200">
           {item.teaser}
         </p>
         {item.result ? (
           <p
             id={`${cardId}-result`}
-            className="rounded-xl border border-white/40 bg-white/70 p-4 text-sm font-medium text-slate-700 backdrop-blur dark:border-white/15 dark:bg-white/10 dark:text-slate-200"
+            className="case-card__result rounded-xl border border-white/40 bg-white/70 p-4 text-sm font-medium text-slate-700 backdrop-blur dark:border-white/20 dark:bg-white/10 dark:text-slate-100"
           >
             {item.result}
           </p>
@@ -321,25 +429,24 @@ function CaseCard({ item, index }: CaseCardProps) {
             variant="primary"
             href={`/cases/${item.slug}`}
             className="min-h-[44px] px-5"
-            data-prevent-card
-            onClick={(event) => {
-              event.stopPropagation();
+            data-qa={`cta-view-case-${item.slug}`}
+            onClick={() => {
               trackClick({ action: 'cta_primary' });
+              sendEvent('view_case', { case_id: item.slug, position: index });
             }}
           >
             Смотреть кейс
           </Button>
-          {item.ctas?.map((cta) => (
+          {item.ctas?.map((cta, ctaIndex) => (
             <Button
               key={cta.label}
               variant={cta.variant || 'secondary'}
               href={cta.href}
               target={cta.kind === 'external' ? '_blank' : undefined}
               rel={cta.kind === 'external' ? 'noopener noreferrer' : undefined}
-              data-prevent-card
               className="min-h-[44px] px-4"
-              onClick={(event) => {
-                event.stopPropagation();
+              data-qa={`cta-case-${item.slug}-${ctaIndex}-${toDataQa(cta.label)}`}
+              onClick={() => {
                 trackClick({ action: 'cta_secondary', label: cta.label, href: cta.href });
               }}
             >

--- a/components/Cases.tsx
+++ b/components/Cases.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import clsx from 'clsx';
+import clsx from '@/lib/clsx';
 
 import Container from '@/components/Container';
 import Card from '@/components/Card';
@@ -196,7 +196,7 @@ export default function Cases() {
 
     const handleResize = () => computeMetrics();
 
-    if (!('ResizeObserver' in window)) {
+    if (typeof ResizeObserver === 'undefined') {
       window.addEventListener('resize', handleResize);
       return () => {
         window.removeEventListener('resize', handleResize);

--- a/components/Cases.tsx
+++ b/components/Cases.tsx
@@ -253,6 +253,7 @@ function CaseCard({ item, index }: CaseCardProps) {
   return (
     <li ref={ref} className="group/card list-none">
       <Card
+        variant="plain"
         aria-labelledby={`${cardId}-title`}
         aria-describedby={item.result ? `${cardId}-result` : undefined}
         className={clsx(

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -15,16 +15,25 @@ export default function Footer() {
             variant="secondary"
             href={TG_URL}
             onClick={() => sendEvent('click_tg_primary', { source: 'footer' })}
+            data-qa="cta-footer-telegram"
+            className="min-h-[44px]"
           >
             Telegram
           </Button>
-          <Button variant="secondary" href={GITHUB_URL}>
+          <Button
+            variant="secondary"
+            href={GITHUB_URL}
+            data-qa="cta-footer-github"
+            className="min-h-[44px]"
+          >
             GitHub
           </Button>
           <Button
             variant="secondary"
             href={RESUME_URL}
             onClick={() => sendEvent('click_resume_pdf')}
+            data-qa="cta-footer-resume"
+            className="min-h-[44px]"
           >
             Резюме (PDF)
           </Button>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -22,6 +22,8 @@ export default function Hero({ onOpenBooking }: { onOpenBooking: () => void }) {
             variant="accent"
             href={TG_URL}
             onClick={() => sendEvent('click_tg_primary', { source: 'hero' })}
+            data-qa="cta-hero-telegram"
+            className="min-h-[44px]"
           >
             Написать в Telegram
           </Button>
@@ -29,6 +31,8 @@ export default function Hero({ onOpenBooking }: { onOpenBooking: () => void }) {
           <Button
             variant="secondary"
             onClick={() => document.getElementById('brief')?.scrollIntoView({ behavior: 'smooth' })}
+            data-qa="cta-hero-brief"
+            className="min-h-[44px]"
           >
             Оставить бриф проекта
           </Button>
@@ -37,6 +41,8 @@ export default function Hero({ onOpenBooking }: { onOpenBooking: () => void }) {
             variant="secondary"
             href={RESUME_URL}
             onClick={() => sendEvent('click_resume_pdf')}
+            data-qa="cta-hero-resume"
+            className="min-h-[44px]"
           >
             Скачать резюме (PDF)
           </Button>
@@ -44,6 +50,8 @@ export default function Hero({ onOpenBooking }: { onOpenBooking: () => void }) {
           <Button
             variant="secondary"
             onClick={() => { sendEvent('tg_booking_click_placeholder', { source: 'hero' }); onOpenBooking(); }}
+            data-qa="cta-hero-booking"
+            className="min-h-[44px]"
           >
             Записаться на 15-мин (скоро)
           </Button>

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -18,7 +18,14 @@ export default function Modal({ open, onClose, title, children }: { open: boolea
       <div ref={ref} className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
         <div className="mb-4 flex items-center justify-between">
           <h3 className="text-lg font-semibold">{title}</h3>
-          <button aria-label="Закрыть" onClick={onClose}>✕</button>
+          <button
+            aria-label="Закрыть"
+            onClick={onClose}
+            data-qa="modal-close"
+            className="rounded-full p-1 text-slate-500 transition hover:text-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400"
+          >
+            ✕
+          </button>
         </div>
         <div>{children}</div>
       </div>

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,8 +1,15 @@
 import Link from 'next/link'
+
+import BackButton from '@/components/BackButton'
 import ThemeToggle from '@/components/ThemeToggle'
 import BackgroundToggle from '@/components/BackgroundToggle' // ← вернули
 
-export default function Nav({ backToCases = false }: { backToCases?: boolean }) {
+type NavProps = {
+  backToCases?: boolean
+  caseId?: string
+}
+
+export default function Nav({ backToCases = false, caseId }: NavProps) {
   return (
     // плотная плашка и там, и там
     <header
@@ -10,9 +17,12 @@ export default function Nav({ backToCases = false }: { backToCases?: boolean }) 
       className="sticky top-0 z-40 border-b border-border supports-[backdrop-filter]:bg-background/80 bg-background/95 backdrop-blur"
     >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 min-w-0">
-        <nav className="flex h-14 items-center justify-between">
+        <nav className="flex h-14 items-center justify-between gap-3">
           {/* левая группа не раздувает ширину */}
-          <div className="flex items-center gap-3 min-w-0 shrink-0">
+          <div className="flex items-center gap-2 min-w-0 shrink-0">
+            {backToCases ? (
+              <BackButton caseId={caseId} />
+            ) : null}
             <Link
               href="/"
               className="font-semibold hidden max-w-[60vw] md:inline text-sm truncate"

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link'
-import Button from '@/components/Button'
 import ThemeToggle from '@/components/ThemeToggle'
 import BackgroundToggle from '@/components/BackgroundToggle' // ← вернули
 
@@ -14,11 +13,6 @@ export default function Nav({ backToCases = false }: { backToCases?: boolean }) 
         <nav className="flex h-14 items-center justify-between">
           {/* левая группа не раздувает ширину */}
           <div className="flex items-center gap-3 min-w-0 shrink-0">
-            {backToCases && (
-              <Button variant="secondary" href="/" className="px-3 py-1.5">
-                ← Назад
-              </Button>
-            )}
             <Link
               href="/"
               className="font-semibold hidden max-w-[60vw] md:inline text-sm truncate"

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -52,9 +52,7 @@ export default function Nav({ backToCases = false, caseId }: NavProps) {
               <Link href="https://t.me" className="opacity-80 hover:opacity-100">
                 Telegram
               </Link>
-              <div className="hidden md:flex rounded-lg p-1.5 hover:bg-[rgb(var(--muted))] transition">
-                <BackgroundToggle aria-label="Переключить фон" />
-              </div>
+              <BackgroundToggle className="hidden md:inline-flex items-center gap-1" aria-label="Переключить фон" />
             </div>
           </div>
         </nav>

--- a/components/Process.tsx
+++ b/components/Process.tsx
@@ -1,10 +1,14 @@
 'use client';
 
+import clsx from '@/lib/clsx';
+
 import Container from '@/components/Container';
 import Card from '@/components/Card';
 import Badge from '@/components/primitives/Badge';
 import { useCardAnalytics } from '@/components/hooks/useCardAnalytics';
+import { useSnapCarousel } from '@/components/hooks/useSnapCarousel';
 import type { BadgeTone } from '@/lib/badge';
+import type { CSSProperties } from 'react';
 
 const steps = [
   {
@@ -74,6 +78,11 @@ const stepVibes: StepVibe[] = [
 ];
 
 export default function Process() {
+  const { listRef, activeIndex, handleKeyDown, handleScroll } = useSnapCarousel(steps.length);
+  const carouselStyle = {
+    '--snap-lg-columns': 'repeat(2, minmax(0, 1fr))',
+  } as CSSProperties;
+
   return (
     <section id="process" className="py-16 sm:py-24">
       <Container>
@@ -87,11 +96,36 @@ export default function Process() {
           </p>
         </header>
 
-        <ul className="grid grid-cols-1 gap-3 sm:gap-4 md:grid-cols-2 md:gap-6" role="list">
-          {steps.map((step, index) => (
-            <StepCard key={step.title} step={step} index={index} />
-          ))}
-        </ul>
+        <div role="group" aria-roledescription="carousel" aria-label="Процесс">
+          <ul
+            ref={listRef}
+            className="case-carousel"
+            role="list"
+            tabIndex={0}
+            onKeyDown={handleKeyDown}
+            onScroll={handleScroll}
+            style={carouselStyle}
+          >
+            {steps.map((step, index) => (
+              <StepCard key={step.title} step={step} index={index} />
+            ))}
+          </ul>
+          {steps.length > 1 ? (
+            <div className="mt-4 flex justify-center gap-2 md:hidden" aria-hidden="true">
+              {steps.map((step, index) => (
+                <span
+                  key={step.title}
+                  className={clsx(
+                    'h-1.5 w-6 rounded-full transition-colors',
+                    activeIndex === index
+                      ? 'bg-white/80 shadow-[0_0_8px_rgba(0,0,0,0.25)] dark:bg-slate-100'
+                      : 'bg-slate-300/60 dark:bg-slate-600/60'
+                  )}
+                />
+              ))}
+            </div>
+          ) : null}
+        </div>
       </Container>
     </section>
   );

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -225,6 +225,7 @@ function ServiceCard({ service, index }: ServiceCardProps) {
             href="#brief"
             className="mt-2 w-full min-h-[44px] justify-center text-sm font-semibold md:w-auto"
             onClick={() => trackClick({ action: 'brief' })}
+            data-qa={`service-${service.id}-cta`}
           >
             Обсудить проект
           </Button>

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import clsx from '@/lib/clsx';
+
 import Container from '@/components/Container';
 import Card from '@/components/Card';
 import Button from '@/components/Button';
 import Badge from '@/components/primitives/Badge';
 import { useCardAnalytics } from '@/components/hooks/useCardAnalytics';
+import { useSnapCarousel } from '@/components/hooks/useSnapCarousel';
 import type { BadgeTone } from '@/lib/badge';
 
 type Service = {
@@ -133,6 +136,8 @@ const serviceVibes: Record<Service['id'], ServiceVibe> = {
 };
 
 export default function Services() {
+  const { listRef, activeIndex, handleKeyDown, handleScroll } = useSnapCarousel(services.length);
+
   return (
     <section id="services" className="py-16 sm:py-24">
       <Container>
@@ -146,11 +151,35 @@ export default function Services() {
           </p>
         </header>
 
-        <ul className="grid grid-cols-1 gap-3 sm:gap-4 md:grid-cols-2 md:gap-6 lg:grid-cols-3" role="list">
-          {services.map((service, index) => (
-            <ServiceCard key={service.id} service={service} index={index} />
-          ))}
-        </ul>
+        <div role="group" aria-roledescription="carousel" aria-label="Услуги">
+          <ul
+            ref={listRef}
+            className="case-carousel"
+            role="list"
+            tabIndex={0}
+            onKeyDown={handleKeyDown}
+            onScroll={handleScroll}
+          >
+            {services.map((service, index) => (
+              <ServiceCard key={service.id} service={service} index={index} />
+            ))}
+          </ul>
+          {services.length > 1 ? (
+            <div className="mt-4 flex justify-center gap-2 md:hidden" aria-hidden="true">
+              {services.map((service, index) => (
+                <span
+                  key={service.id}
+                  className={clsx(
+                    'h-1.5 w-6 rounded-full transition-colors',
+                    activeIndex === index
+                      ? 'bg-white/80 shadow-[0_0_8px_rgba(0,0,0,0.25)] dark:bg-slate-100'
+                      : 'bg-slate-300/60 dark:bg-slate-600/60'
+                  )}
+                />
+              ))}
+            </div>
+          ) : null}
+        </div>
       </Container>
     </section>
   );
@@ -221,7 +250,7 @@ function ServiceCard({ service, index }: ServiceCardProps) {
             {service.budget}
           </Badge>
           <Button
-            variant="primary"
+            variant="accent"
             href="#brief"
             className="mt-2 w-full min-h-[44px] justify-center text-sm font-semibold md:w-auto"
             onClick={() => trackClick({ action: 'brief' })}

--- a/components/Stack.tsx
+++ b/components/Stack.tsx
@@ -36,7 +36,7 @@ const sections: StackSection[] = [
     emoji: '📊',
     badge: 'Аналитика и метрики',
     surface:
-      'bg-gradient-to-br from-sky-50 via-blue-50/85 to-emerald-50 dark:from-sky-500/16 dark:via-blue-500/12 dark:to-emerald-500/12',
+      'bg-gradient-to-br from-sky-50 via-blue-50/85 to-emerald-50 dark:from-sky-500/28 dark:via-blue-500/22 dark:to-emerald-500/22',
     shadow: 'shadow-[0_18px_40px_-18px_rgba(56,189,248,0.32)]',
     halo: 'bg-sky-200/45 dark:bg-sky-500/20',
   },
@@ -52,7 +52,7 @@ const sections: StackSection[] = [
     emoji: '🧩',
     badge: 'Backend / API',
     surface:
-      'bg-gradient-to-br from-purple-50 via-violet-50/85 to-indigo-50 dark:from-purple-500/16 dark:via-violet-500/12 dark:to-indigo-500/12',
+      'bg-gradient-to-br from-purple-50 via-violet-50/85 to-indigo-50 dark:from-purple-500/28 dark:via-violet-500/22 dark:to-indigo-500/22',
     shadow: 'shadow-[0_18px_40px_-18px_rgba(167,139,250,0.32)]',
     halo: 'bg-purple-200/45 dark:bg-purple-500/20',
   },
@@ -68,7 +68,7 @@ const sections: StackSection[] = [
     emoji: '🤖',
     badge: 'TG-боты и автоматизация',
     surface:
-      'bg-gradient-to-br from-amber-50 via-orange-50/85 to-lime-50 dark:from-amber-500/16 dark:via-orange-500/12 dark:to-lime-500/12',
+      'bg-gradient-to-br from-amber-50 via-orange-50/85 to-lime-50 dark:from-amber-500/28 dark:via-orange-500/22 dark:to-lime-500/22',
     shadow: 'shadow-[0_18px_40px_-18px_rgba(251,191,36,0.32)]',
     halo: 'bg-amber-200/45 dark:bg-amber-500/20',
   },
@@ -84,7 +84,7 @@ const sections: StackSection[] = [
     emoji: '🚀',
     badge: 'Сайты и интерфейсы',
     surface:
-      'bg-gradient-to-br from-rose-50 via-pink-50/85 to-emerald-50 dark:from-rose-500/16 dark:via-pink-500/12 dark:to-emerald-500/12',
+      'bg-gradient-to-br from-rose-50 via-pink-50/85 to-emerald-50 dark:from-rose-500/28 dark:via-pink-500/22 dark:to-emerald-500/22',
     shadow: 'shadow-[0_18px_40px_-18px_rgba(244,114,182,0.32)]',
     halo: 'bg-rose-200/45 dark:bg-rose-500/20',
   },

--- a/components/Stack.tsx
+++ b/components/Stack.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import clsx from '@/lib/clsx';
+
 import Container from '@/components/Container';
 import Card from '@/components/Card';
 import Badge from '@/components/primitives/Badge';
 import BulletList from '@/components/primitives/BulletList';
 import { useCardAnalytics } from '@/components/hooks/useCardAnalytics';
+import { useSnapCarousel } from '@/components/hooks/useSnapCarousel';
 import type { BadgeTone } from '@/lib/badge';
 
 type StackSection = {
@@ -94,6 +97,8 @@ const toneBySection: Record<StackSection['id'], BadgeTone> = {
 };
 
 export default function Stack() {
+  const { listRef, activeIndex, handleKeyDown, handleScroll } = useSnapCarousel(sections.length);
+
   return (
     <section id="stack" className="py-16 sm:py-24">
       <Container>
@@ -107,11 +112,35 @@ export default function Stack() {
           </p>
         </header>
 
-        <ul className="grid grid-cols-1 gap-3 sm:gap-4 md:grid-cols-2 md:gap-6 lg:grid-cols-3" role="list">
-          {sections.map((section, index) => (
-            <StackCard key={section.id} section={section} index={index} />
-          ))}
-        </ul>
+        <div role="group" aria-roledescription="carousel" aria-label="Стек и инструменты">
+          <ul
+            ref={listRef}
+            className="case-carousel"
+            role="list"
+            tabIndex={0}
+            onKeyDown={handleKeyDown}
+            onScroll={handleScroll}
+          >
+            {sections.map((section, index) => (
+              <StackCard key={section.id} section={section} index={index} />
+            ))}
+          </ul>
+          {sections.length > 1 ? (
+            <div className="mt-4 flex justify-center gap-2 md:hidden" aria-hidden="true">
+              {sections.map((section, index) => (
+                <span
+                  key={section.id}
+                  className={clsx(
+                    'h-1.5 w-6 rounded-full transition-colors',
+                    activeIndex === index
+                      ? 'bg-white/80 shadow-[0_0_8px_rgba(0,0,0,0.25)] dark:bg-slate-100'
+                      : 'bg-slate-300/60 dark:bg-slate-600/60'
+                  )}
+                />
+              ))}
+            </div>
+          ) : null}
+        </div>
       </Container>
     </section>
   );

--- a/components/Stack.tsx
+++ b/components/Stack.tsx
@@ -36,7 +36,7 @@ const sections: StackSection[] = [
     emoji: '📊',
     badge: 'Аналитика и метрики',
     surface:
-      'bg-gradient-to-br from-sky-100 via-blue-50 to-emerald-100 dark:from-sky-500/20 dark:via-blue-500/12 dark:to-emerald-500/12',
+      'bg-gradient-to-br from-sky-50 via-blue-50/85 to-emerald-50 dark:from-sky-500/16 dark:via-blue-500/12 dark:to-emerald-500/12',
     shadow: 'shadow-[0_18px_40px_-18px_rgba(56,189,248,0.32)]',
     halo: 'bg-sky-200/45 dark:bg-sky-500/20',
   },
@@ -52,7 +52,7 @@ const sections: StackSection[] = [
     emoji: '🧩',
     badge: 'Backend / API',
     surface:
-      'bg-gradient-to-br from-purple-100 via-violet-50 to-indigo-100 dark:from-purple-500/20 dark:via-violet-500/12 dark:to-indigo-500/12',
+      'bg-gradient-to-br from-purple-50 via-violet-50/85 to-indigo-50 dark:from-purple-500/16 dark:via-violet-500/12 dark:to-indigo-500/12',
     shadow: 'shadow-[0_18px_40px_-18px_rgba(167,139,250,0.32)]',
     halo: 'bg-purple-200/45 dark:bg-purple-500/20',
   },
@@ -68,7 +68,7 @@ const sections: StackSection[] = [
     emoji: '🤖',
     badge: 'TG-боты и автоматизация',
     surface:
-      'bg-gradient-to-br from-amber-100 via-orange-50 to-lime-100 dark:from-amber-500/20 dark:via-orange-500/12 dark:to-lime-500/12',
+      'bg-gradient-to-br from-amber-50 via-orange-50/85 to-lime-50 dark:from-amber-500/16 dark:via-orange-500/12 dark:to-lime-500/12',
     shadow: 'shadow-[0_18px_40px_-18px_rgba(251,191,36,0.32)]',
     halo: 'bg-amber-200/45 dark:bg-amber-500/20',
   },
@@ -84,7 +84,7 @@ const sections: StackSection[] = [
     emoji: '🚀',
     badge: 'Сайты и интерфейсы',
     surface:
-      'bg-gradient-to-br from-rose-100 via-pink-50 to-emerald-100 dark:from-rose-500/20 dark:via-pink-500/12 dark:to-emerald-500/12',
+      'bg-gradient-to-br from-rose-50 via-pink-50/85 to-emerald-50 dark:from-rose-500/16 dark:via-pink-500/12 dark:to-emerald-500/12',
     shadow: 'shadow-[0_18px_40px_-18px_rgba(244,114,182,0.32)]',
     halo: 'bg-rose-200/45 dark:bg-rose-500/20',
   },

--- a/components/hooks/useSnapCarousel.ts
+++ b/components/hooks/useSnapCarousel.ts
@@ -1,0 +1,127 @@
+"use client";
+
+import * as React from "react";
+
+type CarouselMetrics = {
+  item: number;
+  gap: number;
+};
+
+export function useSnapCarousel(length: number) {
+  const listRef = React.useRef<HTMLUListElement | null>(null);
+  const metricsRef = React.useRef<CarouselMetrics>({ item: 0, gap: 0 });
+  const rafRef = React.useRef<number>();
+  const [activeIndex, setActiveIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    const node = listRef.current;
+    if (!node || typeof window === "undefined") {
+      return;
+    }
+
+    const computeMetrics = () => {
+      const firstItem = node.querySelector(":scope > li") as HTMLElement | null;
+      if (!firstItem) {
+        metricsRef.current = { item: 0, gap: 0 };
+        return;
+      }
+
+      const styles = window.getComputedStyle(node);
+      const gap = parseFloat(styles.columnGap || styles.gap || "0");
+
+      metricsRef.current = {
+        item: firstItem.getBoundingClientRect().width,
+        gap: Number.isFinite(gap) ? gap : 0,
+      };
+    };
+
+    computeMetrics();
+
+    const handleResize = () => computeMetrics();
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", handleResize);
+      return () => {
+        window.removeEventListener("resize", handleResize);
+      };
+    }
+
+    const resizeObserver = new ResizeObserver(handleResize);
+    resizeObserver.observe(node);
+    node.querySelectorAll(":scope > li").forEach((child) => resizeObserver.observe(child));
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [length]);
+
+  React.useEffect(() => {
+    return () => {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  React.useEffect(() => {
+    setActiveIndex((prev) => {
+      if (length <= 0) return 0;
+      return Math.min(prev, length - 1);
+    });
+  }, [length]);
+
+  const scrollToIndex = React.useCallback(
+    (nextIndex: number) => {
+      const node = listRef.current;
+      if (!node) return;
+      const { item, gap } = metricsRef.current;
+      if (!item) return;
+      const clamped = Math.max(0, Math.min(nextIndex, Math.max(length - 1, 0)));
+      const offset = clamped * (item + gap);
+      node.scrollTo({ left: offset, behavior: "smooth" });
+    },
+    [length]
+  );
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLUListElement>) => {
+      if (length <= 1) return;
+      if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
+        return;
+      }
+      event.preventDefault();
+      const delta = event.key === "ArrowRight" ? 1 : -1;
+      scrollToIndex(activeIndex + delta);
+    },
+    [activeIndex, length, scrollToIndex]
+  );
+
+  const handleScroll = React.useCallback(() => {
+    if (typeof window === "undefined") return;
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+    }
+
+    rafRef.current = window.requestAnimationFrame(() => {
+      const node = listRef.current;
+      if (!node) return;
+      const { item, gap } = metricsRef.current;
+      if (!item) return;
+      const rawIndex = node.scrollLeft / (item + gap || 1);
+      const nextIndex = Math.round(rawIndex);
+      const clamped = Math.max(0, Math.min(nextIndex, Math.max(length - 1, 0)));
+      setActiveIndex((prev) => (prev === clamped ? prev : clamped));
+    });
+  }, [length]);
+
+  return {
+    activeIndex,
+    listRef,
+    handleKeyDown,
+    handleScroll,
+    scrollToIndex,
+  } as const;
+}
+

--- a/components/primitives/Badge.tsx
+++ b/components/primitives/Badge.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import clsx from "clsx";
+import clsx from "@/lib/clsx";
 import { badgeBaseClass, badgeToneClass, type BadgeTone } from "@/lib/badge";
 
 type BadgeProps = React.HTMLAttributes<HTMLSpanElement> & {

--- a/components/primitives/BulletList.tsx
+++ b/components/primitives/BulletList.tsx
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import clsx from "@/lib/clsx";
 import * as React from "react";
 
 type BulletListProps = {

--- a/lib/caseVibes.ts
+++ b/lib/caseVibes.ts
@@ -20,7 +20,7 @@ const palette: CaseVibe[] = [
     label: "A/B",
     tone: "rose",
     surface:
-      "bg-gradient-to-br from-rose-200 via-pink-100 to-amber-100 dark:from-rose-600/45 dark:via-pink-500/35 dark:to-amber-400/30",
+      "bg-gradient-to-br from-rose-50 via-pink-50/85 to-amber-50 dark:from-rose-500/18 dark:via-pink-500/14 dark:to-amber-500/14",
     shadow: "shadow-[0_28px_52px_-26px_rgba(244,114,182,0.6)]",
     accent: "text-rose-700 dark:text-rose-200",
     chip:
@@ -35,7 +35,7 @@ const palette: CaseVibe[] = [
     label: "Ops",
     tone: "emerald",
     surface:
-      "bg-gradient-to-br from-emerald-100 via-sky-50/80 to-lime-100 dark:from-emerald-500/25 dark:via-sky-500/18 dark:to-lime-500/18",
+      "bg-gradient-to-br from-emerald-50 via-sky-50/80 to-lime-50 dark:from-emerald-500/18 dark:via-sky-500/14 dark:to-lime-500/14",
     shadow: "shadow-[0_24px_48px_-24px_rgba(16,185,129,0.38)]",
     accent: "text-emerald-700 dark:text-emerald-200",
     chip:
@@ -50,7 +50,7 @@ const palette: CaseVibe[] = [
     label: "Modeling",
     tone: "purple",
     surface:
-      "bg-gradient-to-br from-violet-100 via-indigo-50/75 to-sky-100 dark:from-violet-500/25 dark:via-indigo-500/18 dark:to-sky-500/16",
+      "bg-gradient-to-br from-violet-50 via-indigo-50/80 to-sky-50 dark:from-violet-500/18 dark:via-indigo-500/14 dark:to-sky-500/14",
     shadow: "shadow-[0_24px_48px_-24px_rgba(129,140,248,0.36)]",
     accent: "text-violet-700 dark:text-violet-200",
     chip:
@@ -65,7 +65,7 @@ const palette: CaseVibe[] = [
     label: "AI",
     tone: "slate",
     surface:
-      "bg-gradient-to-br from-slate-100 via-indigo-50/80 to-sky-100 dark:from-slate-200/28 dark:via-slate-300/20 dark:to-indigo-400/22",
+      "bg-gradient-to-br from-slate-50 via-indigo-50/80 to-sky-50 dark:from-slate-300/18 dark:via-indigo-400/14 dark:to-cyan-400/14",
     shadow: "shadow-[0_26px_52px_-24px_rgba(148,163,184,0.45)]",
     accent: "text-slate-700 dark:text-slate-200",
     chip:
@@ -80,7 +80,7 @@ const palette: CaseVibe[] = [
     label: "Automation",
     tone: "amber",
     surface:
-      "bg-gradient-to-br from-amber-100 via-orange-50/75 to-lime-100 dark:from-amber-500/25 dark:via-orange-500/18 dark:to-lime-500/18",
+      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-lime-50 dark:from-amber-500/18 dark:via-orange-500/14 dark:to-lime-500/14",
     shadow: "shadow-[0_24px_48px_-24px_rgba(251,191,36,0.38)]",
     accent: "text-amber-700 dark:text-amber-200",
     chip:

--- a/lib/caseVibes.ts
+++ b/lib/caseVibes.ts
@@ -20,7 +20,7 @@ const palette: CaseVibe[] = [
     label: "A/B",
     tone: "rose",
     surface:
-      "bg-gradient-to-br from-rose-50 via-pink-50/80 to-amber-50 dark:from-rose-500/55 dark:via-pink-500/40 dark:to-amber-500/38",
+      "bg-gradient-to-br from-rose-50 via-pink-50/80 to-amber-50 dark:from-rose-900/80 dark:via-pink-900/65 dark:to-amber-900/60",
     shadow: "shadow-[0_28px_52px_-26px_rgba(244,114,182,0.6)]",
     accent: "text-rose-700 dark:text-rose-200",
     chip:
@@ -35,7 +35,7 @@ const palette: CaseVibe[] = [
     label: "Ops",
     tone: "emerald",
     surface:
-      "bg-gradient-to-br from-emerald-50 via-lime-50/80 to-sky-50 dark:from-emerald-500/45 dark:via-lime-500/40 dark:to-sky-500/40",
+      "bg-gradient-to-br from-emerald-50 via-lime-50/80 to-sky-50 dark:from-emerald-900/78 dark:via-lime-900/60 dark:to-sky-900/65",
     shadow: "shadow-[0_24px_48px_-24px_rgba(16,185,129,0.38)]",
     accent: "text-emerald-700 dark:text-emerald-200",
     chip:
@@ -50,7 +50,7 @@ const palette: CaseVibe[] = [
     label: "Modeling",
     tone: "purple",
     surface:
-      "bg-gradient-to-br from-purple-50 via-violet-50/80 to-rose-50 dark:from-purple-500/45 dark:via-violet-500/38 dark:to-rose-500/38",
+      "bg-gradient-to-br from-purple-50 via-violet-50/80 to-rose-50 dark:from-purple-900/78 dark:via-violet-900/62 dark:to-rose-900/60",
     shadow: "shadow-[0_24px_48px_-24px_rgba(129,140,248,0.36)]",
     accent: "text-violet-700 dark:text-violet-200",
     chip:
@@ -65,7 +65,7 @@ const palette: CaseVibe[] = [
     label: "AI",
     tone: "slate",
     surface:
-      "bg-gradient-to-br from-sky-50 via-cyan-50/80 to-emerald-50 dark:from-sky-500/45 dark:via-cyan-500/40 dark:to-emerald-500/40",
+      "bg-gradient-to-br from-sky-50 via-cyan-50/80 to-emerald-50 dark:from-sky-950/80 dark:via-cyan-900/62 dark:to-emerald-900/60",
     shadow: "shadow-[0_26px_52px_-24px_rgba(148,163,184,0.45)]",
     accent: "text-slate-700 dark:text-slate-200",
     chip:
@@ -80,7 +80,7 @@ const palette: CaseVibe[] = [
     label: "Automation",
     tone: "amber",
     surface:
-      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-lime-50 dark:from-amber-500/45 dark:via-orange-500/40 dark:to-lime-500/40",
+      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-lime-50 dark:from-amber-900/78 dark:via-orange-900/62 dark:to-lime-900/58",
     shadow: "shadow-[0_24px_48px_-24px_rgba(251,191,36,0.38)]",
     accent: "text-amber-700 dark:text-amber-200",
     chip:

--- a/lib/caseVibes.ts
+++ b/lib/caseVibes.ts
@@ -20,7 +20,7 @@ const palette: CaseVibe[] = [
     label: "A/B",
     tone: "rose",
     surface:
-      "bg-gradient-to-br from-rose-50 via-pink-50/85 to-amber-50 dark:from-rose-500/18 dark:via-pink-500/14 dark:to-amber-500/14",
+      "bg-gradient-to-br from-rose-50 via-pink-50/85 to-amber-50 dark:from-rose-500/32 dark:via-pink-500/26 dark:to-amber-500/24",
     shadow: "shadow-[0_28px_52px_-26px_rgba(244,114,182,0.6)]",
     accent: "text-rose-700 dark:text-rose-200",
     chip:
@@ -35,7 +35,7 @@ const palette: CaseVibe[] = [
     label: "Ops",
     tone: "emerald",
     surface:
-      "bg-gradient-to-br from-emerald-50 via-sky-50/80 to-lime-50 dark:from-emerald-500/18 dark:via-sky-500/14 dark:to-lime-500/14",
+      "bg-gradient-to-br from-emerald-50 via-sky-50/80 to-lime-50 dark:from-emerald-500/30 dark:via-sky-500/24 dark:to-lime-500/24",
     shadow: "shadow-[0_24px_48px_-24px_rgba(16,185,129,0.38)]",
     accent: "text-emerald-700 dark:text-emerald-200",
     chip:
@@ -50,7 +50,7 @@ const palette: CaseVibe[] = [
     label: "Modeling",
     tone: "purple",
     surface:
-      "bg-gradient-to-br from-violet-50 via-indigo-50/80 to-sky-50 dark:from-violet-500/18 dark:via-indigo-500/14 dark:to-sky-500/14",
+      "bg-gradient-to-br from-violet-50 via-indigo-50/80 to-sky-50 dark:from-violet-500/30 dark:via-indigo-500/24 dark:to-sky-500/24",
     shadow: "shadow-[0_24px_48px_-24px_rgba(129,140,248,0.36)]",
     accent: "text-violet-700 dark:text-violet-200",
     chip:
@@ -65,7 +65,7 @@ const palette: CaseVibe[] = [
     label: "AI",
     tone: "slate",
     surface:
-      "bg-gradient-to-br from-slate-50 via-indigo-50/80 to-sky-50 dark:from-slate-300/18 dark:via-indigo-400/14 dark:to-cyan-400/14",
+      "bg-gradient-to-br from-slate-50 via-indigo-50/80 to-sky-50 dark:from-slate-300/28 dark:via-indigo-400/24 dark:to-cyan-400/22",
     shadow: "shadow-[0_26px_52px_-24px_rgba(148,163,184,0.45)]",
     accent: "text-slate-700 dark:text-slate-200",
     chip:
@@ -80,7 +80,7 @@ const palette: CaseVibe[] = [
     label: "Automation",
     tone: "amber",
     surface:
-      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-lime-50 dark:from-amber-500/18 dark:via-orange-500/14 dark:to-lime-500/14",
+      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-lime-50 dark:from-amber-500/30 dark:via-orange-500/24 dark:to-lime-500/24",
     shadow: "shadow-[0_24px_48px_-24px_rgba(251,191,36,0.38)]",
     accent: "text-amber-700 dark:text-amber-200",
     chip:

--- a/lib/caseVibes.ts
+++ b/lib/caseVibes.ts
@@ -20,7 +20,7 @@ const palette: CaseVibe[] = [
     label: "A/B",
     tone: "rose",
     surface:
-      "bg-gradient-to-br from-rose-50 via-pink-50/80 to-amber-50 dark:from-rose-500/15 dark:via-pink-500/15 dark:to-amber-500/15",
+      "bg-gradient-to-br from-rose-50 via-pink-50/80 to-amber-50 dark:from-rose-500/35 dark:via-pink-500/25 dark:to-amber-500/25",
     shadow: "shadow-[0_28px_52px_-26px_rgba(244,114,182,0.6)]",
     accent: "text-rose-700 dark:text-rose-200",
     chip:

--- a/lib/caseVibes.ts
+++ b/lib/caseVibes.ts
@@ -20,11 +20,11 @@ const palette: CaseVibe[] = [
     label: "A/B",
     tone: "rose",
     surface:
-      "bg-gradient-to-br from-rose-50 via-pink-50/80 to-amber-50 dark:from-rose-500/35 dark:via-pink-500/25 dark:to-amber-500/25",
+      "bg-gradient-to-br from-rose-50 via-pink-50/80 to-amber-50 dark:from-rose-500/55 dark:via-pink-500/40 dark:to-amber-500/38",
     shadow: "shadow-[0_28px_52px_-26px_rgba(244,114,182,0.6)]",
     accent: "text-rose-700 dark:text-rose-200",
     chip:
-      "backdrop-blur border border-rose-200/60 bg-white/85 text-rose-800 dark:border-rose-400/35 dark:bg-rose-500/25 dark:text-rose-50",
+      "backdrop-blur border border-rose-200/60 bg-white/85 text-rose-800 dark:border-rose-400/45 dark:bg-rose-500/32 dark:text-rose-50",
     link: "text-rose-700 hover:text-rose-800 dark:text-rose-200 dark:hover:text-rose-100",
     glow:
       "bg-gradient-to-br from-rose-200/65 via-pink-200/50 to-amber-200/45 dark:from-rose-500/35 dark:via-pink-500/30 dark:to-amber-400/25",
@@ -35,11 +35,11 @@ const palette: CaseVibe[] = [
     label: "Ops",
     tone: "emerald",
     surface:
-      "bg-gradient-to-br from-emerald-50 via-lime-50/80 to-sky-50 dark:from-emerald-500/15 dark:via-lime-500/15 dark:to-sky-500/15",
+      "bg-gradient-to-br from-emerald-50 via-lime-50/80 to-sky-50 dark:from-emerald-500/45 dark:via-lime-500/40 dark:to-sky-500/40",
     shadow: "shadow-[0_24px_48px_-24px_rgba(16,185,129,0.38)]",
     accent: "text-emerald-700 dark:text-emerald-200",
     chip:
-      "backdrop-blur border border-emerald-200/60 bg-white/85 text-emerald-800 dark:border-emerald-400/35 dark:bg-emerald-500/25 dark:text-emerald-50",
+      "backdrop-blur border border-emerald-200/60 bg-white/85 text-emerald-800 dark:border-emerald-400/45 dark:bg-emerald-500/30 dark:text-emerald-50",
     link: "text-emerald-700 hover:text-emerald-800 dark:text-emerald-200 dark:hover:text-emerald-100",
     glow:
       "bg-gradient-to-br from-emerald-200/55 via-sky-200/45 to-lime-200/40 dark:from-emerald-500/30 dark:via-sky-500/24 dark:to-lime-500/20",
@@ -50,11 +50,11 @@ const palette: CaseVibe[] = [
     label: "Modeling",
     tone: "purple",
     surface:
-      "bg-gradient-to-br from-purple-50 via-violet-50/80 to-rose-50 dark:from-purple-500/15 dark:via-violet-500/15 dark:to-rose-500/15",
+      "bg-gradient-to-br from-purple-50 via-violet-50/80 to-rose-50 dark:from-purple-500/45 dark:via-violet-500/38 dark:to-rose-500/38",
     shadow: "shadow-[0_24px_48px_-24px_rgba(129,140,248,0.36)]",
     accent: "text-violet-700 dark:text-violet-200",
     chip:
-      "backdrop-blur border border-violet-200/60 bg-white/85 text-violet-800 dark:border-violet-400/35 dark:bg-violet-500/25 dark:text-violet-50",
+      "backdrop-blur border border-violet-200/60 bg-white/85 text-violet-800 dark:border-violet-400/45 dark:bg-violet-500/32 dark:text-violet-50",
     link: "text-violet-700 hover:text-violet-800 dark:text-violet-200 dark:hover:text-violet-100",
     glow:
       "bg-gradient-to-br from-violet-200/55 via-indigo-200/45 to-sky-200/40 dark:from-violet-500/30 dark:via-indigo-500/22 dark:to-sky-500/18",
@@ -65,11 +65,11 @@ const palette: CaseVibe[] = [
     label: "AI",
     tone: "slate",
     surface:
-      "bg-gradient-to-br from-sky-50 via-cyan-50/80 to-emerald-50 dark:from-sky-500/15 dark:via-cyan-500/15 dark:to-emerald-500/15",
+      "bg-gradient-to-br from-sky-50 via-cyan-50/80 to-emerald-50 dark:from-sky-500/45 dark:via-cyan-500/40 dark:to-emerald-500/40",
     shadow: "shadow-[0_26px_52px_-24px_rgba(148,163,184,0.45)]",
     accent: "text-slate-700 dark:text-slate-200",
     chip:
-      "backdrop-blur border border-slate-200/60 bg-white/85 text-slate-800 dark:border-slate-400/35 dark:bg-slate-500/25 dark:text-slate-50",
+      "backdrop-blur border border-slate-200/60 bg-white/85 text-slate-800 dark:border-slate-400/45 dark:bg-slate-500/30 dark:text-slate-50",
     link: "text-indigo-600 hover:text-indigo-700 dark:text-indigo-200 dark:hover:text-indigo-100",
     glow:
       "bg-gradient-to-br from-slate-200/60 via-indigo-200/45 to-sky-200/35 dark:from-slate-200/28 dark:via-indigo-300/22 dark:to-cyan-300/18",
@@ -80,11 +80,11 @@ const palette: CaseVibe[] = [
     label: "Automation",
     tone: "amber",
     surface:
-      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-lime-50 dark:from-amber-500/15 dark:via-orange-500/15 dark:to-lime-500/15",
+      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-lime-50 dark:from-amber-500/45 dark:via-orange-500/40 dark:to-lime-500/40",
     shadow: "shadow-[0_24px_48px_-24px_rgba(251,191,36,0.38)]",
     accent: "text-amber-700 dark:text-amber-200",
     chip:
-      "backdrop-blur border border-amber-200/60 bg-white/85 text-amber-800 dark:border-amber-400/35 dark:bg-amber-500/25 dark:text-amber-50",
+      "backdrop-blur border border-amber-200/60 bg-white/85 text-amber-800 dark:border-amber-400/45 dark:bg-amber-500/32 dark:text-amber-50",
     link: "text-amber-700 hover:text-amber-800 dark:text-amber-200 dark:hover:text-amber-100",
     glow:
       "bg-gradient-to-br from-amber-200/55 via-orange-200/45 to-lime-200/40 dark:from-amber-500/30 dark:via-orange-500/24 dark:to-lime-500/20",

--- a/lib/caseVibes.ts
+++ b/lib/caseVibes.ts
@@ -20,7 +20,7 @@ const palette: CaseVibe[] = [
     label: "A/B",
     tone: "rose",
     surface:
-      "bg-gradient-to-br from-rose-50 via-pink-50/85 to-amber-50 dark:from-rose-500/32 dark:via-pink-500/26 dark:to-amber-500/24",
+      "bg-gradient-to-br from-rose-50 via-pink-50/85 to-amber-50 dark:from-rose-500/40 dark:via-pink-500/32 dark:to-amber-500/28",
     shadow: "shadow-[0_28px_52px_-26px_rgba(244,114,182,0.6)]",
     accent: "text-rose-700 dark:text-rose-200",
     chip:
@@ -35,7 +35,7 @@ const palette: CaseVibe[] = [
     label: "Ops",
     tone: "emerald",
     surface:
-      "bg-gradient-to-br from-emerald-50 via-sky-50/80 to-lime-50 dark:from-emerald-500/30 dark:via-sky-500/24 dark:to-lime-500/24",
+      "bg-gradient-to-br from-emerald-50 via-sky-50/80 to-lime-50 dark:from-emerald-500/38 dark:via-sky-500/30 dark:to-lime-500/28",
     shadow: "shadow-[0_24px_48px_-24px_rgba(16,185,129,0.38)]",
     accent: "text-emerald-700 dark:text-emerald-200",
     chip:
@@ -50,7 +50,7 @@ const palette: CaseVibe[] = [
     label: "Modeling",
     tone: "purple",
     surface:
-      "bg-gradient-to-br from-violet-50 via-indigo-50/80 to-sky-50 dark:from-violet-500/30 dark:via-indigo-500/24 dark:to-sky-500/24",
+      "bg-gradient-to-br from-violet-50 via-indigo-50/80 to-sky-50 dark:from-violet-500/38 dark:via-indigo-500/30 dark:to-sky-500/28",
     shadow: "shadow-[0_24px_48px_-24px_rgba(129,140,248,0.36)]",
     accent: "text-violet-700 dark:text-violet-200",
     chip:
@@ -65,7 +65,7 @@ const palette: CaseVibe[] = [
     label: "AI",
     tone: "slate",
     surface:
-      "bg-gradient-to-br from-slate-50 via-indigo-50/80 to-sky-50 dark:from-slate-300/28 dark:via-indigo-400/24 dark:to-cyan-400/22",
+      "bg-gradient-to-br from-slate-50 via-indigo-50/80 to-sky-50 dark:from-slate-300/35 dark:via-indigo-400/28 dark:to-cyan-400/26",
     shadow: "shadow-[0_26px_52px_-24px_rgba(148,163,184,0.45)]",
     accent: "text-slate-700 dark:text-slate-200",
     chip:
@@ -80,7 +80,7 @@ const palette: CaseVibe[] = [
     label: "Automation",
     tone: "amber",
     surface:
-      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-lime-50 dark:from-amber-500/30 dark:via-orange-500/24 dark:to-lime-500/24",
+      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-lime-50 dark:from-amber-500/38 dark:via-orange-500/30 dark:to-lime-500/28",
     shadow: "shadow-[0_24px_48px_-24px_rgba(251,191,36,0.38)]",
     accent: "text-amber-700 dark:text-amber-200",
     chip:

--- a/lib/caseVibes.ts
+++ b/lib/caseVibes.ts
@@ -20,7 +20,7 @@ const palette: CaseVibe[] = [
     label: "A/B",
     tone: "rose",
     surface:
-      "bg-gradient-to-br from-rose-50 via-pink-50/85 to-amber-50 dark:from-rose-500/40 dark:via-pink-500/32 dark:to-amber-500/28",
+      "bg-gradient-to-br from-rose-50 via-pink-50/80 to-amber-50 dark:from-rose-500/15 dark:via-pink-500/15 dark:to-amber-500/15",
     shadow: "shadow-[0_28px_52px_-26px_rgba(244,114,182,0.6)]",
     accent: "text-rose-700 dark:text-rose-200",
     chip:
@@ -35,7 +35,7 @@ const palette: CaseVibe[] = [
     label: "Ops",
     tone: "emerald",
     surface:
-      "bg-gradient-to-br from-emerald-50 via-sky-50/80 to-lime-50 dark:from-emerald-500/38 dark:via-sky-500/30 dark:to-lime-500/28",
+      "bg-gradient-to-br from-emerald-50 via-lime-50/80 to-sky-50 dark:from-emerald-500/15 dark:via-lime-500/15 dark:to-sky-500/15",
     shadow: "shadow-[0_24px_48px_-24px_rgba(16,185,129,0.38)]",
     accent: "text-emerald-700 dark:text-emerald-200",
     chip:
@@ -50,7 +50,7 @@ const palette: CaseVibe[] = [
     label: "Modeling",
     tone: "purple",
     surface:
-      "bg-gradient-to-br from-violet-50 via-indigo-50/80 to-sky-50 dark:from-violet-500/38 dark:via-indigo-500/30 dark:to-sky-500/28",
+      "bg-gradient-to-br from-purple-50 via-violet-50/80 to-rose-50 dark:from-purple-500/15 dark:via-violet-500/15 dark:to-rose-500/15",
     shadow: "shadow-[0_24px_48px_-24px_rgba(129,140,248,0.36)]",
     accent: "text-violet-700 dark:text-violet-200",
     chip:
@@ -65,7 +65,7 @@ const palette: CaseVibe[] = [
     label: "AI",
     tone: "slate",
     surface:
-      "bg-gradient-to-br from-slate-50 via-indigo-50/80 to-sky-50 dark:from-slate-300/35 dark:via-indigo-400/28 dark:to-cyan-400/26",
+      "bg-gradient-to-br from-sky-50 via-cyan-50/80 to-emerald-50 dark:from-sky-500/15 dark:via-cyan-500/15 dark:to-emerald-500/15",
     shadow: "shadow-[0_26px_52px_-24px_rgba(148,163,184,0.45)]",
     accent: "text-slate-700 dark:text-slate-200",
     chip:
@@ -80,7 +80,7 @@ const palette: CaseVibe[] = [
     label: "Automation",
     tone: "amber",
     surface:
-      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-lime-50 dark:from-amber-500/38 dark:via-orange-500/30 dark:to-lime-500/28",
+      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-lime-50 dark:from-amber-500/15 dark:via-orange-500/15 dark:to-lime-500/15",
     shadow: "shadow-[0_24px_48px_-24px_rgba(251,191,36,0.38)]",
     accent: "text-amber-700 dark:text-amber-200",
     chip:

--- a/lib/clsx.ts
+++ b/lib/clsx.ts
@@ -1,0 +1,36 @@
+export type ClassValue = ClassDictionary | ClassArray | string | number | boolean | null | undefined;
+
+interface ClassDictionary {
+  [key: string]: any;
+}
+
+interface ClassArray extends Array<ClassValue> {}
+
+function toVal(value: ClassValue): string[] {
+  if (!value && value !== 0) {
+    return [];
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    return [String(value)];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(toVal);
+  }
+
+  if (typeof value === 'object') {
+    return Object.keys(value).filter((key) => {
+      if (!Object.prototype.hasOwnProperty.call(value, key)) {
+        return false;
+      }
+      return Boolean((value as ClassDictionary)[key]);
+    });
+  }
+
+  return [];
+}
+
+export default function clsx(...inputs: ClassValue[]): string {
+  return inputs.flatMap(toVal).join(' ');
+}


### PR DESCRIPTION
## Summary
- add a horizontal, snap-scrolling carousel for case cards on mobile with keyboard support and progress indicator
- widen case detail content, remove duplicate back button, and improve readability in dark mode
- scope CTA interactions to explicit buttons, add analytics events, and provide data-qa hooks for automated tests

## Testing
- npm run lint *(fails: requires interactive ESLint setup prompt and no configuration is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68d532d3e10483299251d68cbcc0ab1f