### PR TITLE
Align case card backgrounds with services section

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -530,9 +530,7 @@
 }
 
 .dark .case-card::after {
-  opacity: 1;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 28%, rgba(15, 23, 42, 0.26) 100%);
-  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.14);
+  opacity: 0;
 }
 
 .case-card__result {

--- a/app/globals.css
+++ b/app/globals.css
@@ -127,15 +127,14 @@
   margin: .3rem 0;
 }
 
-.prose ul>li::marker,
-.prose ol>li::marker {
-  color: rgb(var(--foreground));
+.prose ul>li::marker {
+  color: rgb(var(--accent));
   font-weight: 800;
 }
 
-.dark .prose ul>li::marker,
-.dark .prose ol>li::marker {
-  color: rgb(var(--foreground));
+.prose ol>li::marker {
+  color: color-mix(in oklab, rgb(var(--accent)) 80%, rgb(var(--foreground)) 20%);
+  font-weight: 800;
 }
 
 /* inline-код в тексте */

--- a/app/globals.css
+++ b/app/globals.css
@@ -129,13 +129,13 @@
 
 .prose ul>li::marker,
 .prose ol>li::marker {
-  color: color-mix(in oklab, rgb(var(--foreground)) 88%, rgb(var(--background)) 12%);
+  color: rgb(var(--foreground));
   font-weight: 800;
 }
 
 .dark .prose ul>li::marker,
 .dark .prose ol>li::marker {
-  color: color-mix(in oklab, white 80%, rgb(24 24 27) 20%);
+  color: rgb(var(--foreground));
 }
 
 /* inline-код в тексте */

--- a/app/globals.css
+++ b/app/globals.css
@@ -601,31 +601,61 @@
   box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.4), 0 26px 52px -30px rgba(14, 165, 233, 0.65);
 }
 
-.case-card__cta--primary {
-  background: linear-gradient(135deg, rgba(244, 114, 182, 0.96), rgba(192, 132, 252, 0.96));
+.case-card__cta--light {
+  background: #ffffff;
   color: #0f172a !important;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 20px 44px -30px rgba(15, 23, 42, 0.28);
+}
+
+.case-card__cta--light:hover {
+  background: #f8fafc;
+}
+
+.case-card__cta--light:focus-visible {
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.35), 0 20px 44px -30px rgba(15, 23, 42, 0.35);
+}
+
+.dark .case-card__cta--light {
+  background: rgba(255, 255, 255, 0.98);
+  color: #020617 !important;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  box-shadow: 0 22px 46px -32px rgba(15, 23, 42, 0.45);
+}
+
+.dark .case-card__cta--light:hover {
+  background: rgba(248, 250, 252, 0.98);
+}
+
+.dark .case-card__cta--light:focus-visible {
+  box-shadow: 0 0 0 1px rgba(226, 232, 240, 0.45), 0 22px 46px -32px rgba(15, 23, 42, 0.52);
+}
+
+.case-card__cta--primary {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.98), rgba(14, 165, 233, 0.95));
+  color: #f8fafc !important;
   border-color: transparent;
-  box-shadow: 0 26px 52px -28px rgba(192, 132, 252, 0.45);
+  box-shadow: 0 24px 48px -28px rgba(37, 99, 235, 0.45);
 }
 
 .case-card__cta--primary:hover {
-  background: linear-gradient(135deg, rgba(249, 168, 212, 0.98), rgba(221, 214, 254, 0.96));
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.98), rgba(34, 211, 238, 0.95));
 }
 
 .case-card__cta--primary:focus-visible {
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.4), 0 26px 52px -28px rgba(192, 132, 252, 0.5);
+  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.35), 0 24px 48px -28px rgba(37, 99, 235, 0.55);
 }
 
 .dark .case-card__cta--primary {
-  background: linear-gradient(135deg, rgba(244, 114, 182, 0.9), rgba(168, 85, 247, 0.92));
-  color: #0b1120 !important;
-  box-shadow: 0 28px 54px -30px rgba(168, 85, 247, 0.65);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(56, 189, 248, 0.88));
+  color: #f8fafc !important;
+  box-shadow: 0 26px 52px -30px rgba(14, 165, 233, 0.6);
 }
 
 .dark .case-card__cta--primary:hover {
-  background: linear-gradient(135deg, rgba(249, 168, 212, 0.94), rgba(196, 181, 253, 0.94));
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.92), rgba(45, 212, 191, 0.9));
 }
 
 .dark .case-card__cta--primary:focus-visible {
-  box-shadow: 0 0 0 1px rgba(226, 232, 240, 0.45), 0 28px 54px -30px rgba(168, 85, 247, 0.7);
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.4), 0 26px 52px -30px rgba(14, 165, 233, 0.65);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -572,90 +572,62 @@
   position: relative;
 }
 
-.case-card__cta--accent {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.98), rgba(14, 165, 233, 0.95));
-  color: #061023 !important;
-  border-color: transparent;
-  box-shadow: 0 24px 48px -28px rgba(37, 99, 235, 0.45);
-}
-
-.case-card__cta--accent:hover {
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.98), rgba(34, 211, 238, 0.95));
-}
-
-.case-card__cta--accent:focus-visible {
-  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.35), 0 24px 48px -28px rgba(37, 99, 235, 0.55);
-}
-
-.dark .case-card__cta--accent {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(56, 189, 248, 0.88));
-  color: #020817 !important;
-  box-shadow: 0 26px 52px -30px rgba(14, 165, 233, 0.6);
-}
-
-.dark .case-card__cta--accent:hover {
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.92), rgba(45, 212, 191, 0.9));
-}
-
-.dark .case-card__cta--accent:focus-visible {
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.4), 0 26px 52px -30px rgba(14, 165, 233, 0.65);
-}
-
-.case-card__cta--light {
-  background: #ffffff;
-  color: #0f172a !important;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  box-shadow: 0 20px 44px -30px rgba(15, 23, 42, 0.28);
-}
-
-.case-card__cta--light:hover {
-  background: #f8fafc;
-}
-
-.case-card__cta--light:focus-visible {
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.35), 0 20px 44px -30px rgba(15, 23, 42, 0.35);
-}
-
-.dark .case-card__cta--light {
-  background: rgba(255, 255, 255, 0.98);
-  color: #020617 !important;
-  border: 1px solid rgba(148, 163, 184, 0.32);
-  box-shadow: 0 22px 46px -32px rgba(15, 23, 42, 0.45);
-}
-
-.dark .case-card__cta--light:hover {
-  background: rgba(248, 250, 252, 0.98);
-}
-
-.dark .case-card__cta--light:focus-visible {
-  box-shadow: 0 0 0 1px rgba(226, 232, 240, 0.45), 0 22px 46px -32px rgba(15, 23, 42, 0.52);
-}
-
 .case-card__cta--primary {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.98), rgba(14, 165, 233, 0.95));
+  background: #000000;
   color: #f8fafc !important;
-  border-color: transparent;
-  box-shadow: 0 24px 48px -28px rgba(37, 99, 235, 0.45);
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  box-shadow: 0 24px 48px -30px rgba(15, 23, 42, 0.45);
 }
 
 .case-card__cta--primary:hover {
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.98), rgba(34, 211, 238, 0.95));
+  background: #111827;
 }
 
 .case-card__cta--primary:focus-visible {
-  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.35), 0 24px 48px -28px rgba(37, 99, 235, 0.55);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.35), 0 24px 48px -30px rgba(15, 23, 42, 0.5);
 }
 
 .dark .case-card__cta--primary {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(56, 189, 248, 0.88));
-  color: #f8fafc !important;
-  box-shadow: 0 26px 52px -30px rgba(14, 165, 233, 0.6);
+  background: #ffffff;
+  color: #020617 !important;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: 0 26px 52px -34px rgba(15, 23, 42, 0.58);
 }
 
 .dark .case-card__cta--primary:hover {
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.92), rgba(45, 212, 191, 0.9));
+  background: #f8fafc;
 }
 
 .dark .case-card__cta--primary:focus-visible {
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.4), 0 26px 52px -30px rgba(14, 165, 233, 0.65);
+  box-shadow: 0 0 0 2px rgba(226, 232, 240, 0.55), 0 26px 52px -34px rgba(15, 23, 42, 0.6);
+}
+
+.case-card__cta--blue {
+  background: #2563eb;
+  color: #f8fafc !important;
+  border: 1px solid #1d4ed8;
+  box-shadow: 0 24px 48px -30px rgba(37, 99, 235, 0.55);
+}
+
+.case-card__cta--blue:hover {
+  background: #1d4ed8;
+}
+
+.case-card__cta--blue:focus-visible {
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.35), 0 24px 48px -30px rgba(37, 99, 235, 0.6);
+}
+
+.dark .case-card__cta--blue {
+  background: #2563eb;
+  color: #f8fafc !important;
+  border: 1px solid rgba(37, 99, 235, 0.6);
+  box-shadow: 0 26px 52px -34px rgba(37, 99, 235, 0.6);
+}
+
+.dark .case-card__cta--blue:hover {
+  background: #1d4ed8;
+}
+
+.dark .case-card__cta--blue:focus-visible {
+  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.45), 0 26px 52px -34px rgba(37, 99, 235, 0.65);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -531,7 +531,8 @@
 
 .dark .case-card::after {
   opacity: 1;
-  background: linear-gradient(180deg, rgba(8, 10, 18, 0) 38%, rgba(8, 10, 18, 0.48) 100%);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 28%, rgba(15, 23, 42, 0.26) 100%);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.14);
 }
 
 .case-card__result {
@@ -557,9 +558,9 @@
 
 .dark .case-card__result {
   color: #f6f7ff;
-  background: linear-gradient(180deg, rgba(29, 36, 52, 0.52) 0%, rgba(12, 19, 33, 0.78) 100%);
-  border-color: rgba(148, 163, 184, 0.35);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18), 0 20px 36px -28px rgba(15, 23, 42, 0.65);
+  background: linear-gradient(180deg, rgba(42, 57, 92, 0.52) 0%, rgba(17, 26, 44, 0.68) 100%);
+  border-color: rgba(148, 163, 184, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16), 0 18px 32px -26px rgba(15, 23, 42, 0.58);
 }
 
 .case-card__cta {

--- a/app/prose.css
+++ b/app/prose.css
@@ -26,6 +26,22 @@
   @apply text-base text-slate-700/90 dark:text-slate-200/90;
 }
 
+.case-article :where(ul > li)::marker {
+  color: theme('colors.slate.400');
+}
+
+.dark .case-article :where(ul > li)::marker {
+  color: theme('colors.slate.200');
+}
+
+.case-article :where(ol > li)::marker {
+  color: theme('colors.slate.500');
+}
+
+.dark .case-article :where(ol > li)::marker {
+  color: theme('colors.slate.100');
+}
+
 .case-article :where(blockquote):not(:where(.not-prose *)) {
   @apply border-l-0 rounded-3xl bg-gradient-to-r from-sky-500/10 via-slate-100/70 to-transparent px-6 py-4 text-[0.95rem] font-medium text-slate-800 shadow-sm dark:from-sky-500/15 dark:via-white/10 dark:to-transparent dark:text-slate-100;
 }

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -34,7 +34,7 @@ export default function BackButton({ caseId, className }: BackButtonProps) {
         "dark:border-[color:color-mix(in_oklab,_rgb(var(--accent))_30%,_rgb(var(--border))_70%)]",
         "dark:bg-[color:color-mix(in_oklab,_rgb(var(--accent))_22%,_rgb(var(--background))_78%)]",
         "dark:text-[color:color-mix(in_oklab,_rgb(var(--accent-foreground))_65%,_rgb(var(--foreground))_35%)]",
-        "-ml-2 sm:-ml-3 md:-ml-8 lg:-ml-16 xl:-ml-24 2xl:-ml-32",
+        "sm:-ml-3 md:-ml-8 lg:-ml-16 xl:-ml-24 2xl:-ml-32",
         className
       )}
     >

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -3,8 +3,14 @@
 import { useRouter } from "next/navigation";
 
 import { sendEvent } from "@/lib/analytics";
+import clsx from "@/lib/clsx";
 
-export default function BackButton({ caseId }: { caseId?: string }) {
+type BackButtonProps = {
+  caseId?: string;
+  className?: string;
+};
+
+export default function BackButton({ caseId, className }: BackButtonProps) {
   const router = useRouter();
 
   return (
@@ -20,7 +26,17 @@ export default function BackButton({ caseId }: { caseId?: string }) {
           window.location.href = "/#cases";
         }
       }}
-      className="inline-flex items-center gap-1 text-sm font-medium text-slate-700 opacity-80 transition hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--accent))] dark:text-slate-200 md:-ml-8 lg:-ml-16 xl:-ml-24 2xl:-ml-32"
+      className={clsx(
+        "inline-flex items-center gap-2 rounded-full border border-[color:color-mix(in_oklab,_rgb(var(--accent))_40%,_rgb(var(--border))_60%)]",
+        "bg-[color:color-mix(in_oklab,_rgb(var(--accent))_14%,_rgb(var(--background))_86%)] px-3 py-1.5 text-sm font-medium",
+        "text-[color:color-mix(in_oklab,_rgb(var(--accent))_70%,_rgb(var(--foreground))_30%)] shadow-sm transition",
+        "hover:-translate-x-0.5 hover:shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--accent))]",
+        "dark:border-[color:color-mix(in_oklab,_rgb(var(--accent))_30%,_rgb(var(--border))_70%)]",
+        "dark:bg-[color:color-mix(in_oklab,_rgb(var(--accent))_22%,_rgb(var(--background))_78%)]",
+        "dark:text-[color:color-mix(in_oklab,_rgb(var(--accent-foreground))_65%,_rgb(var(--foreground))_35%)]",
+        "-ml-2 sm:-ml-3 md:-ml-8 lg:-ml-16 xl:-ml-24 2xl:-ml-32",
+        className
+      )}
     >
       ← Назад
     </button>

--- a/components/Cases.tsx
+++ b/components/Cases.tsx
@@ -57,7 +57,7 @@ const cases: CaseItem[] = [
         label: 'Код',
         href: 'https://github.com/IDSidorov-data/mobile-game-ab-test-analysis',
         kind: 'external',
-        variant: 'accent',
+        variant: 'ghost',
       },
     ],
   },
@@ -76,7 +76,7 @@ const cases: CaseItem[] = [
         label: 'Демо',
         href: 'https://log-calc.streamlit.app/',
         kind: 'external',
-        variant: 'accent',
+        variant: 'ghost',
       },
       {
         label: 'ТЗ v2',
@@ -88,7 +88,7 @@ const cases: CaseItem[] = [
         label: 'Код',
         href: 'https://github.com/IDSidorov-data/logistics_calculator',
         kind: 'external',
-        variant: 'accent',
+        variant: 'ghost',
       },
     ],
   },
@@ -106,13 +106,13 @@ const cases: CaseItem[] = [
         label: 'Код (core)',
         href: 'https://github.com/IDSidorov-data/scenario-core',
         kind: 'external',
-        variant: 'accent',
+        variant: 'ghost',
       },
       {
         label: 'Код (landing)',
         href: 'https://github.com/IDSidorov-data/scenario-landing',
         kind: 'external',
-        variant: 'accent',
+        variant: 'ghost',
       },
     ],
   },
@@ -130,7 +130,7 @@ const cases: CaseItem[] = [
         label: 'Код',
         href: 'https://github.com/IDSidorov-data/loki-reborn-ai-assistant',
         kind: 'external',
-        variant: 'accent',
+        variant: 'ghost',
       },
     ],
   },
@@ -336,9 +336,9 @@ function CaseCard({ item, index }: CaseCardProps) {
         </div>
         <footer className="mt-auto flex flex-wrap items-center gap-3 pt-2">
           <Button
-            variant="accent"
+            variant="ghost"
             href={`/cases/${item.slug}`}
-            className="case-card__cta case-card__cta--accent case-card__cta--primary min-h-[44px] px-5"
+            className="case-card__cta case-card__cta--primary min-h-[44px] px-5"
             data-qa={`cta-view-case-${item.slug}`}
             onClick={() => {
               trackClick({ action: 'cta_primary' });
@@ -349,6 +349,10 @@ function CaseCard({ item, index }: CaseCardProps) {
           </Button>
           {item.ctas?.map((cta, ctaIndex) => {
             const variant = cta.variant || 'secondary';
+            const normalizedLabel = cta.label.toLowerCase();
+            const isCodeLike = normalizedLabel.startsWith('код');
+            const isDemo = normalizedLabel.startsWith('демо');
+            const whiteTone = isCodeLike || isDemo;
             const accentTone = variant === 'accent';
 
             return (
@@ -360,7 +364,11 @@ function CaseCard({ item, index }: CaseCardProps) {
                 rel={cta.kind === 'external' ? 'noopener noreferrer' : undefined}
                 className={clsx(
                   'case-card__cta min-h-[44px] px-4',
-                  accentTone ? 'case-card__cta--accent' : 'case-card__cta--secondary'
+                  whiteTone
+                    ? 'case-card__cta--light'
+                    : accentTone
+                    ? 'case-card__cta--accent'
+                    : 'case-card__cta--secondary'
                 )}
                 data-qa={`cta-case-${item.slug}-${ctaIndex}-${toDataQa(cta.label)}`}
                 onClick={() => {

--- a/components/Cases.tsx
+++ b/components/Cases.tsx
@@ -253,7 +253,7 @@ function CaseCard({ item, index }: CaseCardProps) {
   return (
     <li ref={ref} className="group/card list-none">
       <Card
-        variant="soft"
+        variant="plain"
         aria-labelledby={`${cardId}-title`}
         aria-describedby={item.result ? `${cardId}-result` : undefined}
         className={clsx(

--- a/components/Cases.tsx
+++ b/components/Cases.tsx
@@ -349,11 +349,12 @@ function CaseCard({ item, index }: CaseCardProps) {
           </Button>
           {item.ctas?.map((cta, ctaIndex) => {
             const variant = cta.variant || 'secondary';
-            const normalizedLabel = cta.label.toLowerCase();
+            const normalizedLabel = cta.label.toLowerCase().trim();
             const isCodeLike = normalizedLabel.startsWith('код');
             const isDemo = normalizedLabel.startsWith('демо');
-            const whiteTone = isCodeLike || isDemo;
+            const isTz = normalizedLabel.startsWith('тз');
             const accentTone = variant === 'accent';
+            const blueTone = isCodeLike || isDemo || isTz || accentTone;
 
             return (
               <Button
@@ -364,11 +365,7 @@ function CaseCard({ item, index }: CaseCardProps) {
                 rel={cta.kind === 'external' ? 'noopener noreferrer' : undefined}
                 className={clsx(
                   'case-card__cta min-h-[44px] px-4',
-                  whiteTone
-                    ? 'case-card__cta--light'
-                    : accentTone
-                    ? 'case-card__cta--accent'
-                    : 'case-card__cta--secondary'
+                  blueTone ? 'case-card__cta--blue' : 'case-card__cta--secondary'
                 )}
                 data-qa={`cta-case-${item.slug}-${ctaIndex}-${toDataQa(cta.label)}`}
                 onClick={() => {

--- a/components/Cases.tsx
+++ b/components/Cases.tsx
@@ -253,7 +253,7 @@ function CaseCard({ item, index }: CaseCardProps) {
   return (
     <li ref={ref} className="group/card list-none">
       <Card
-        variant="plain"
+        variant="soft"
         aria-labelledby={`${cardId}-title`}
         aria-describedby={item.result ? `${cardId}-result` : undefined}
         className={clsx(

--- a/components/Cases.tsx
+++ b/components/Cases.tsx
@@ -253,7 +253,6 @@ function CaseCard({ item, index }: CaseCardProps) {
   return (
     <li ref={ref} className="group/card list-none">
       <Card
-        variant="plain"
         aria-labelledby={`${cardId}-title`}
         aria-describedby={item.result ? `${cardId}-result` : undefined}
         className={clsx(

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -17,12 +17,12 @@ export default function Nav({ backToCases = false, caseId }: NavProps) {
       className="sticky top-0 z-40 border-b border-border supports-[backdrop-filter]:bg-background/80 bg-background/95 backdrop-blur"
     >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 min-w-0">
-        <nav className="flex h-14 items-center gap-4">
+        <nav className="flex h-14 items-center gap-2.5 md:gap-4">
           {backToCases ? (
             <BackButton caseId={caseId} className="shrink-0" />
           ) : null}
 
-          <div className="flex h-full w-full items-center justify-between gap-3">
+          <div className="flex h-full w-full items-center justify-between gap-2 md:gap-3">
             <Link
               href="/"
               className="font-semibold hidden max-w-[60vw] md:inline text-sm truncate"
@@ -31,11 +31,11 @@ export default function Nav({ backToCases = false, caseId }: NavProps) {
             </Link>
 
             {/* правая группа не сжимается и не ломает ширину */}
-            <div className="flex items-center gap-2 md:gap-4 shrink-0">
+            <div className="flex items-center gap-1.5 md:gap-4 shrink-0">
               <div className="rounded-lg p-1.5 hover:bg-[rgb(var(--muted))] transition">
                 <ThemeToggle aria-label="Переключить тему" />
               </div>
-              <div className="flex items-center gap-3 md:gap-4">
+              <div className="flex items-center gap-1.5 md:gap-4">
                 <Link href="/#services" className="opacity-80 hover:opacity-100">
                   Услуги
                 </Link>

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -17,42 +17,42 @@ export default function Nav({ backToCases = false, caseId }: NavProps) {
       className="sticky top-0 z-40 border-b border-border supports-[backdrop-filter]:bg-background/80 bg-background/95 backdrop-blur"
     >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 min-w-0">
-        <nav className="flex h-14 items-center justify-between gap-3">
-          {/* левая группа не раздувает ширину */}
-          <div className="flex items-center gap-2 min-w-0 shrink-0">
-            {backToCases ? (
-              <BackButton caseId={caseId} />
-            ) : null}
+        <nav className="flex h-14 items-center gap-4">
+          {backToCases ? (
+            <BackButton caseId={caseId} className="shrink-0" />
+          ) : null}
+
+          <div className="flex h-full w-full items-center justify-between gap-3">
             <Link
               href="/"
               className="font-semibold hidden max-w-[60vw] md:inline text-sm truncate"
             >
               Иван Сидоров · Системный архитектор
             </Link>
-          </div>
 
-          {/* правая группа не сжимается и не ломает ширину */}
-          <div className="flex items-center gap-1 md:gap-4 shrink-0">
-            <div className="rounded-lg p-1.5 hover:bg-[rgb(var(--muted))] transition">
-              <ThemeToggle aria-label="Переключить тему" />
-            </div>
-            <div className="flex items-center gap-3 md:gap-4">
-              <Link href="/#services" className="opacity-80 hover:opacity-100">
-                Услуги
-              </Link>
-              <Link href="/#cases" className="opacity-80 hover:opacity-100">
-                Кейсы
-              </Link>
-              <Link href="/#process" className="opacity-80 hover:opacity-100">
-                Процесс
-              </Link>
-              <Link href="https://github.com" className="opacity-80 hover:opacity-100">
-                GitHub
-              </Link>
-              <Link href="https://t.me" className="opacity-80 hover:opacity-100">
-                Telegram
-              </Link>
-              <BackgroundToggle className="hidden md:inline-flex items-center gap-1" aria-label="Переключить фон" />
+            {/* правая группа не сжимается и не ломает ширину */}
+            <div className="flex items-center gap-2 md:gap-4 shrink-0">
+              <div className="rounded-lg p-1.5 hover:bg-[rgb(var(--muted))] transition">
+                <ThemeToggle aria-label="Переключить тему" />
+              </div>
+              <div className="flex items-center gap-3 md:gap-4">
+                <Link href="/#services" className="opacity-80 hover:opacity-100">
+                  Услуги
+                </Link>
+                <Link href="/#cases" className="opacity-80 hover:opacity-100">
+                  Кейсы
+                </Link>
+                <Link href="/#process" className="opacity-80 hover:opacity-100">
+                  Процесс
+                </Link>
+                <Link href="https://github.com" className="opacity-80 hover:opacity-100">
+                  GitHub
+                </Link>
+                <Link href="https://t.me" className="opacity-80 hover:opacity-100">
+                  Telegram
+                </Link>
+                <BackgroundToggle className="hidden md:inline-flex items-center gap-1" aria-label="Переключить фон" />
+              </div>
             </div>
           </div>
         </nav>

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -252,7 +252,7 @@ function ServiceCard({ service, index }: ServiceCardProps) {
           <Button
             variant="secondary"
             href="#brief"
-            className="mt-2 w-full min-h-[44px] justify-center rounded-xl border border-transparent bg-white text-sm font-semibold text-slate-900 shadow-sm ring-1 ring-transparent transition hover:bg-slate-50 focus-visible:outline-sky-500 md:w-auto dark:bg-white dark:text-slate-900"
+            className="mt-2 w-full min-h-[44px] justify-center rounded-xl border border-transparent bg-black text-sm font-semibold text-white shadow-sm ring-1 ring-transparent transition hover:bg-neutral-900 focus-visible:outline-sky-500 md:w-auto dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
             onClick={() => trackClick({ action: 'brief' })}
             data-qa={`service-${service.id}-cta`}
           >

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -250,9 +250,9 @@ function ServiceCard({ service, index }: ServiceCardProps) {
             {service.budget}
           </Badge>
           <Button
-            variant="accent"
+            variant="secondary"
             href="#brief"
-            className="mt-2 w-full min-h-[44px] justify-center text-sm font-semibold md:w-auto"
+            className="mt-2 w-full min-h-[44px] justify-center rounded-xl border border-transparent bg-white text-sm font-semibold text-slate-900 shadow-sm ring-1 ring-transparent transition hover:bg-slate-50 focus-visible:outline-sky-500 md:w-auto dark:bg-white dark:text-slate-900"
             onClick={() => trackClick({ action: 'brief' })}
             data-qa={`service-${service.id}-cta`}
           >

--- a/components/Stack.tsx
+++ b/components/Stack.tsx
@@ -36,9 +36,9 @@ const sections: StackSection[] = [
     emoji: '📊',
     badge: 'Аналитика и метрики',
     surface:
-      'bg-gradient-to-br from-sky-50 via-blue-50/85 to-emerald-50 dark:from-sky-500/28 dark:via-blue-500/22 dark:to-emerald-500/22',
-    shadow: 'shadow-[0_18px_40px_-18px_rgba(56,189,248,0.32)]',
-    halo: 'bg-sky-200/45 dark:bg-sky-500/20',
+      'bg-gradient-to-br from-amber-50 via-orange-50/80 to-rose-50 dark:from-amber-500/15 dark:via-orange-500/15 dark:to-rose-500/15',
+    shadow: 'shadow-[0_20px_40px_-22px_rgba(245,158,11,0.35)]',
+    halo: 'bg-amber-200/40 dark:bg-amber-500/20',
   },
   {
     id: 'backend',
@@ -52,9 +52,9 @@ const sections: StackSection[] = [
     emoji: '🧩',
     badge: 'Backend / API',
     surface:
-      'bg-gradient-to-br from-purple-50 via-violet-50/85 to-indigo-50 dark:from-purple-500/28 dark:via-violet-500/22 dark:to-indigo-500/22',
-    shadow: 'shadow-[0_18px_40px_-18px_rgba(167,139,250,0.32)]',
-    halo: 'bg-purple-200/45 dark:bg-purple-500/20',
+      'bg-gradient-to-br from-sky-50 via-cyan-50/80 to-emerald-50 dark:from-sky-500/15 dark:via-cyan-500/15 dark:to-emerald-500/15',
+    shadow: 'shadow-[0_20px_40px_-22px_rgba(14,165,233,0.32)]',
+    halo: 'bg-sky-200/40 dark:bg-sky-500/20',
   },
   {
     id: 'automation',
@@ -68,9 +68,9 @@ const sections: StackSection[] = [
     emoji: '🤖',
     badge: 'TG-боты и автоматизация',
     surface:
-      'bg-gradient-to-br from-amber-50 via-orange-50/85 to-lime-50 dark:from-amber-500/28 dark:via-orange-500/22 dark:to-lime-500/22',
-    shadow: 'shadow-[0_18px_40px_-18px_rgba(251,191,36,0.32)]',
-    halo: 'bg-amber-200/45 dark:bg-amber-500/20',
+      'bg-gradient-to-br from-emerald-50 via-lime-50/80 to-sky-50 dark:from-emerald-500/15 dark:via-lime-500/15 dark:to-sky-500/15',
+    shadow: 'shadow-[0_20px_40px_-22px_rgba(16,185,129,0.32)]',
+    halo: 'bg-emerald-200/40 dark:bg-emerald-500/20',
   },
   {
     id: 'product',
@@ -84,16 +84,16 @@ const sections: StackSection[] = [
     emoji: '🚀',
     badge: 'Сайты и интерфейсы',
     surface:
-      'bg-gradient-to-br from-rose-50 via-pink-50/85 to-emerald-50 dark:from-rose-500/28 dark:via-pink-500/22 dark:to-emerald-500/22',
-    shadow: 'shadow-[0_18px_40px_-18px_rgba(244,114,182,0.32)]',
-    halo: 'bg-rose-200/45 dark:bg-rose-500/20',
+      'bg-gradient-to-br from-purple-50 via-violet-50/80 to-rose-50 dark:from-purple-500/15 dark:via-violet-500/15 dark:to-rose-500/15',
+    shadow: 'shadow-[0_20px_40px_-22px_rgba(147,51,234,0.32)]',
+    halo: 'bg-purple-200/40 dark:bg-purple-500/20',
   },
 ];
 const toneBySection: Record<StackSection['id'], BadgeTone> = {
-  analytics: 'sky',
-  backend: 'purple',
+  analytics: 'amber',
+  backend: 'sky',
   automation: 'emerald',
-  product: 'rose',
+  product: 'purple',
 };
 
 export default function Stack() {

--- a/content/cases/ab-test-mobile-game.mdx
+++ b/content/cases/ab-test-mobile-game.mdx
@@ -18,7 +18,6 @@ links:
 <div className="mt-3 flex flex-wrap gap-2">
   <span className="chip chip-positive"><strong>D7</strong>: +0.82 п.п. (p=0.0016)</span>
   <span className="chip chip-neutral">Выборка: gate_30 = 44&nbsp;700; gate_40 = 45&nbsp;489</span>
-  <a className="chip chip-neutral" href="https://github.com/IDSidorov-data/mobile-game-ab-test-analysis" target="_blank" rel="noopener noreferrer">GitHub</a>
 </div>
 
 ## Контекст

--- a/content/cases/logistics-calculator.mdx
+++ b/content/cases/logistics-calculator.mdx
@@ -19,9 +19,6 @@ links:
 
 <div className="mt-3 flex flex-wrap gap-2">
   <span className="chip chip-positive"><strong>Экономия</strong>: ~200 ч разработки</span>
-  <a className="chip chip-neutral" href="https://log-calc.streamlit.app/" target="_blank" rel="noopener noreferrer">Демо</a>
-  <a className="chip chip-neutral" href="https://github.com/IDSidorov-data/logistics_calculator" target="_blank" rel="noopener noreferrer">GitHub (MVP v1)</a>
-  <a className="chip chip-neutral" href="https://github.com/IDSidorov-data/logistics_calculator/blob/main/MVP_v2_SPEC.md" target="_blank" rel="noopener noreferrer">ТЗ на MVP v2</a>
 </div>
 
 ![Демо (gif)](/cases/logistics-calculator/demo.gif)

--- a/content/cases/loki-assistant.mdx
+++ b/content/cases/loki-assistant.mdx
@@ -17,7 +17,6 @@ links:
 <div className="mt-3 flex flex-wrap gap-2">
   <span className="chip chip-neutral select-text"><strong>Потоковый TTS</strong>&nbsp;+&nbsp;прерывание</span>
   <span className="chip chip-neutral select-text">3 контура: локальный · текстовый · визуальный</span>
-  <a className="chip chip-neutral select-text" href="https://github.com/IDSidorov-data/loki-reborn-ai-assistant" target="_blank" rel="noopener noreferrer">GitHub</a>
 </div>
 
 

--- a/content/cases/scenario.mdx
+++ b/content/cases/scenario.mdx
@@ -19,12 +19,6 @@ links:
   </ul>
 </div>
 
-<div className="mt-3 flex flex-wrap gap-2">
-  <a className="chip chip-positive" href="https://github.com/IDSidorov-data/scenario-core" target="_blank" rel="noopener noreferrer">Код (core)</a>
-  <a className="chip chip-positive" href="https://github.com/IDSidorov-data/scenario-landing" target="_blank" rel="noopener noreferrer">Код (landing)</a>
-</div>
-
-
 ## Контекст
 
 Нужно быстро и прозрачно отвечать на вопросы юнит‑экономики: «что будет, если…?», «какие драйверы LTV/маржи важнее?», «где узкое место?». Таблички и разрозненные скрипты не масштабируются → сделал <strong>ядро сценариев</strong> с модульной декомпозицией и воспроизводимыми расчётами.

--- a/lib/caseVibes.ts
+++ b/lib/caseVibes.ts
@@ -20,75 +20,75 @@ const palette: CaseVibe[] = [
     label: "A/B",
     tone: "rose",
     surface:
-      "bg-gradient-to-br from-rose-50/85 via-white/95 to-amber-50/80 dark:from-rose-500/18 dark:via-pink-500/16 dark:to-amber-500/14",
-    shadow: "shadow-[0_28px_52px_-26px_rgba(244,114,182,0.6)]",
-    accent: "text-rose-700 dark:text-rose-200",
+      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-rose-50 dark:from-amber-500/15 dark:via-orange-500/15 dark:to-rose-500/15",
+    shadow: "shadow-[0_20px_40px_-22px_rgba(245,158,11,0.35)]",
+    accent: "text-amber-700 dark:text-amber-200",
     chip:
-      "backdrop-blur border border-rose-200/60 bg-white/85 text-rose-800 dark:border-rose-400/45 dark:bg-rose-500/32 dark:text-rose-50",
-    link: "text-rose-700 hover:text-rose-800 dark:text-rose-200 dark:hover:text-rose-100",
+      "backdrop-blur border border-amber-200/60 bg-white/85 text-amber-800 dark:border-amber-400/45 dark:bg-amber-500/32 dark:text-amber-50",
+    link: "text-amber-700 hover:text-amber-800 dark:text-amber-200 dark:hover:text-amber-100",
     glow:
-      "bg-gradient-to-br from-rose-200/65 via-pink-200/50 to-amber-200/45 dark:from-rose-500/35 dark:via-pink-500/30 dark:to-amber-400/25",
-    halo: "bg-rose-200/60 dark:bg-rose-500/30",
+      "bg-gradient-to-br from-amber-200/55 via-orange-200/45 to-rose-200/40 dark:from-amber-500/28 dark:via-orange-500/24 dark:to-rose-500/20",
+    halo: "bg-amber-200/40 dark:bg-amber-500/20",
   },
   {
     emoji: "🚚",
     label: "Ops",
     tone: "emerald",
     surface:
-      "bg-gradient-to-br from-emerald-50/85 via-white/95 to-sky-50/80 dark:from-emerald-500/18 dark:via-lime-500/16 dark:to-sky-500/14",
-    shadow: "shadow-[0_24px_48px_-24px_rgba(16,185,129,0.38)]",
-    accent: "text-emerald-700 dark:text-emerald-200",
+      "bg-gradient-to-br from-sky-50 via-cyan-50/80 to-emerald-50 dark:from-sky-500/15 dark:via-cyan-500/15 dark:to-emerald-500/15",
+    shadow: "shadow-[0_20px_40px_-22px_rgba(14,165,233,0.32)]",
+    accent: "text-sky-700 dark:text-sky-200",
     chip:
-      "backdrop-blur border border-emerald-200/60 bg-white/85 text-emerald-800 dark:border-emerald-400/45 dark:bg-emerald-500/30 dark:text-emerald-50",
-    link: "text-emerald-700 hover:text-emerald-800 dark:text-emerald-200 dark:hover:text-emerald-100",
+      "backdrop-blur border border-sky-200/60 bg-white/85 text-sky-800 dark:border-sky-400/45 dark:bg-sky-500/32 dark:text-sky-50",
+    link: "text-sky-700 hover:text-sky-800 dark:text-sky-200 dark:hover:text-sky-100",
     glow:
-      "bg-gradient-to-br from-emerald-200/55 via-sky-200/45 to-lime-200/40 dark:from-emerald-500/30 dark:via-sky-500/24 dark:to-lime-500/20",
-    halo: "bg-emerald-200/55 dark:bg-emerald-500/28",
+      "bg-gradient-to-br from-sky-200/55 via-cyan-200/45 to-emerald-200/40 dark:from-sky-500/28 dark:via-cyan-500/24 dark:to-emerald-500/20",
+    halo: "bg-sky-200/40 dark:bg-sky-500/20",
   },
   {
     emoji: "🧠",
     label: "Modeling",
     tone: "purple",
     surface:
-      "bg-gradient-to-br from-purple-50/85 via-white/95 to-rose-50/80 dark:from-purple-500/18 dark:via-violet-500/16 dark:to-rose-500/14",
-    shadow: "shadow-[0_24px_48px_-24px_rgba(129,140,248,0.36)]",
-    accent: "text-violet-700 dark:text-violet-200",
+      "bg-gradient-to-br from-purple-50 via-violet-50/80 to-rose-50 dark:from-purple-500/15 dark:via-violet-500/15 dark:to-rose-500/15",
+    shadow: "shadow-[0_20px_40px_-22px_rgba(147,51,234,0.32)]",
+    accent: "text-purple-700 dark:text-purple-200",
     chip:
-      "backdrop-blur border border-violet-200/60 bg-white/85 text-violet-800 dark:border-violet-400/45 dark:bg-violet-500/32 dark:text-violet-50",
-    link: "text-violet-700 hover:text-violet-800 dark:text-violet-200 dark:hover:text-violet-100",
+      "backdrop-blur border border-purple-200/60 bg-white/85 text-purple-800 dark:border-purple-400/45 dark:bg-purple-500/32 dark:text-purple-50",
+    link: "text-purple-700 hover:text-purple-800 dark:text-purple-200 dark:hover:text-purple-100",
     glow:
-      "bg-gradient-to-br from-violet-200/55 via-indigo-200/45 to-sky-200/40 dark:from-violet-500/30 dark:via-indigo-500/22 dark:to-sky-500/18",
-    halo: "bg-violet-200/55 dark:bg-violet-500/28",
+      "bg-gradient-to-br from-purple-200/55 via-violet-200/45 to-rose-200/40 dark:from-purple-500/28 dark:via-violet-500/24 dark:to-rose-500/20",
+    halo: "bg-purple-200/40 dark:bg-purple-500/20",
   },
   {
     emoji: "🤖",
     label: "AI",
     tone: "slate",
     surface:
-      "bg-gradient-to-br from-sky-50/85 via-white/95 to-emerald-50/80 dark:from-sky-500/18 dark:via-cyan-500/16 dark:to-emerald-500/14",
-    shadow: "shadow-[0_26px_52px_-24px_rgba(148,163,184,0.45)]",
-    accent: "text-slate-700 dark:text-slate-200",
+      "bg-gradient-to-br from-emerald-50 via-lime-50/80 to-sky-50 dark:from-emerald-500/15 dark:via-lime-500/15 dark:to-sky-500/15",
+    shadow: "shadow-[0_20px_40px_-22px_rgba(16,185,129,0.32)]",
+    accent: "text-emerald-700 dark:text-emerald-200",
     chip:
-      "backdrop-blur border border-slate-200/60 bg-white/85 text-slate-800 dark:border-slate-400/45 dark:bg-slate-500/30 dark:text-slate-50",
-    link: "text-indigo-600 hover:text-indigo-700 dark:text-indigo-200 dark:hover:text-indigo-100",
+      "backdrop-blur border border-emerald-200/60 bg-white/85 text-emerald-800 dark:border-emerald-400/45 dark:bg-emerald-500/32 dark:text-emerald-50",
+    link: "text-emerald-700 hover:text-emerald-800 dark:text-emerald-200 dark:hover:text-emerald-100",
     glow:
-      "bg-gradient-to-br from-slate-200/60 via-indigo-200/45 to-sky-200/35 dark:from-slate-200/28 dark:via-indigo-300/22 dark:to-cyan-300/18",
-    halo: "bg-slate-200/60 dark:bg-slate-300/30",
+      "bg-gradient-to-br from-emerald-200/55 via-lime-200/45 to-sky-200/40 dark:from-emerald-500/28 dark:via-lime-500/24 dark:to-sky-500/20",
+    halo: "bg-emerald-200/40 dark:bg-emerald-500/20",
   },
   {
     emoji: "🛠️",
     label: "Automation",
     tone: "amber",
     surface:
-      "bg-gradient-to-br from-amber-50/85 via-white/95 to-lime-50/80 dark:from-amber-500/18 dark:via-orange-500/16 dark:to-lime-500/14",
-    shadow: "shadow-[0_24px_48px_-24px_rgba(251,191,36,0.38)]",
-    accent: "text-amber-700 dark:text-amber-200",
+      "bg-gradient-to-br from-slate-50/40 via-white/60 to-white/90 dark:from-slate-900/60 dark:via-slate-900/40 dark:to-slate-900/30",
+    shadow: "shadow-[0_20px_40px_-22px_rgba(15,23,42,0.28)]",
+    accent: "text-slate-700 dark:text-slate-200",
     chip:
-      "backdrop-blur border border-amber-200/60 bg-white/85 text-amber-800 dark:border-amber-400/45 dark:bg-amber-500/32 dark:text-amber-50",
-    link: "text-amber-700 hover:text-amber-800 dark:text-amber-200 dark:hover:text-amber-100",
+      "backdrop-blur border border-slate-200/60 bg-white/85 text-slate-800 dark:border-slate-400/45 dark:bg-slate-500/30 dark:text-slate-50",
+    link: "text-slate-700 hover:text-slate-800 dark:text-slate-200 dark:hover:text-slate-100",
     glow:
-      "bg-gradient-to-br from-amber-200/55 via-orange-200/45 to-lime-200/40 dark:from-amber-500/30 dark:via-orange-500/24 dark:to-lime-500/20",
-    halo: "bg-amber-200/55 dark:bg-amber-500/28",
+      "bg-gradient-to-br from-slate-200/55 via-zinc-200/45 to-white/40 dark:from-slate-700/28 dark:via-zinc-700/24 dark:to-slate-800/20",
+    halo: "bg-slate-200/35 dark:bg-slate-700/25",
   },
 ];
 

--- a/lib/caseVibes.ts
+++ b/lib/caseVibes.ts
@@ -20,7 +20,7 @@ const palette: CaseVibe[] = [
     label: "A/B",
     tone: "rose",
     surface:
-      "bg-gradient-to-br from-rose-50 via-pink-50/80 to-amber-50 dark:from-rose-900/80 dark:via-pink-900/65 dark:to-amber-900/60",
+      "bg-gradient-to-br from-rose-50/85 via-white/95 to-amber-50/80 dark:from-rose-500/18 dark:via-pink-500/16 dark:to-amber-500/14",
     shadow: "shadow-[0_28px_52px_-26px_rgba(244,114,182,0.6)]",
     accent: "text-rose-700 dark:text-rose-200",
     chip:
@@ -35,7 +35,7 @@ const palette: CaseVibe[] = [
     label: "Ops",
     tone: "emerald",
     surface:
-      "bg-gradient-to-br from-emerald-50 via-lime-50/80 to-sky-50 dark:from-emerald-900/78 dark:via-lime-900/60 dark:to-sky-900/65",
+      "bg-gradient-to-br from-emerald-50/85 via-white/95 to-sky-50/80 dark:from-emerald-500/18 dark:via-lime-500/16 dark:to-sky-500/14",
     shadow: "shadow-[0_24px_48px_-24px_rgba(16,185,129,0.38)]",
     accent: "text-emerald-700 dark:text-emerald-200",
     chip:
@@ -50,7 +50,7 @@ const palette: CaseVibe[] = [
     label: "Modeling",
     tone: "purple",
     surface:
-      "bg-gradient-to-br from-purple-50 via-violet-50/80 to-rose-50 dark:from-purple-900/78 dark:via-violet-900/62 dark:to-rose-900/60",
+      "bg-gradient-to-br from-purple-50/85 via-white/95 to-rose-50/80 dark:from-purple-500/18 dark:via-violet-500/16 dark:to-rose-500/14",
     shadow: "shadow-[0_24px_48px_-24px_rgba(129,140,248,0.36)]",
     accent: "text-violet-700 dark:text-violet-200",
     chip:
@@ -65,7 +65,7 @@ const palette: CaseVibe[] = [
     label: "AI",
     tone: "slate",
     surface:
-      "bg-gradient-to-br from-sky-50 via-cyan-50/80 to-emerald-50 dark:from-sky-950/80 dark:via-cyan-900/62 dark:to-emerald-900/60",
+      "bg-gradient-to-br from-sky-50/85 via-white/95 to-emerald-50/80 dark:from-sky-500/18 dark:via-cyan-500/16 dark:to-emerald-500/14",
     shadow: "shadow-[0_26px_52px_-24px_rgba(148,163,184,0.45)]",
     accent: "text-slate-700 dark:text-slate-200",
     chip:
@@ -80,7 +80,7 @@ const palette: CaseVibe[] = [
     label: "Automation",
     tone: "amber",
     surface:
-      "bg-gradient-to-br from-amber-50 via-orange-50/80 to-lime-50 dark:from-amber-900/78 dark:via-orange-900/62 dark:to-lime-900/58",
+      "bg-gradient-to-br from-amber-50/85 via-white/95 to-lime-50/80 dark:from-amber-500/18 dark:via-orange-500/16 dark:to-lime-500/14",
     shadow: "shadow-[0_24px_48px_-24px_rgba(251,191,36,0.38)]",
     accent: "text-amber-700 dark:text-amber-200",
     chip:


### PR DESCRIPTION
## Summary
- switch case carousel cards to use the soft card variant so their base styling matches the services section
- refresh case palette background gradients to mirror the lighter, translucent style used for service cards in both light and dark themes

## Testing
- `npm run lint` *(fails: command prompts for initial ESLint configuration and cannot be run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d57219a66483299c1e89a9710a3042