### PR TITLE
Use arrow glyphs in metric badge

### DIFF
--- a/components/Cases.tsx
+++ b/components/Cases.tsx
@@ -69,7 +69,9 @@ const cases: CaseItem[] = [
     tags: ['Streamlit', 'Python', 'Product Discovery'],
     result:
       'Предотвращена лишняя разработка (~200 часов); MVP собран за 5 часов.',
-    metrics: [{ label: 'Экономия', value: '~200 ч разработки', positive: true }],
+    metrics: [
+      { label: 'Экономия разработки', value: '~200 ч', note: 'оценка', positive: true },
+    ],
     status: 'delivered',
     ctas: [
       {
@@ -143,8 +145,8 @@ const cases: CaseItem[] = [
     result:
       'Ключевой отчёт: 7 мин → 15 сек (−96%); экономия ~300 000 ₽/мес при текущем объёме.',
     metrics: [
-      { label: 'Время', value: '7 мин → 15 сек', positive: true },
-      { label: 'Экономия', value: '~300k ₽/мес', note: 'оценка', positive: true },
+      { label: 'Время отчёта', value: '7 мин → 15 сек', note: '−96%', positive: true },
+      { label: 'Экономия бюджета', value: '~300k ₽/мес', note: 'оценка', positive: true },
     ],
     nda: true,
   },
@@ -298,13 +300,14 @@ function CaseCard({ item, index }: CaseCardProps) {
           </p>
         ) : null}
         {item.metrics && item.metrics.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-3">
             {item.metrics.map((metric, metricIndex) => (
               <MetricBadge
                 key={`${item.slug}-metric-${metricIndex}`}
                 value={metric.value}
                 label={metric.label}
-                direction={metric.positive === false ? 'down' : 'up'}
+                note={metric.note}
+                positive={metric.positive}
               />
             ))}
           </div>

--- a/components/Cases.tsx
+++ b/components/Cases.tsx
@@ -69,9 +69,7 @@ const cases: CaseItem[] = [
     tags: ['Streamlit', 'Python', 'Product Discovery'],
     result:
       'Предотвращена лишняя разработка (~200 часов); MVP собран за 5 часов.',
-    metrics: [
-      { label: 'Экономия разработки', value: '~200 ч', note: 'оценка', positive: true },
-    ],
+    metrics: [{ label: '', value: 'Экономия ~200 ч разработки', positive: true }],
     status: 'delivered',
     ctas: [
       {
@@ -145,8 +143,8 @@ const cases: CaseItem[] = [
     result:
       'Ключевой отчёт: 7 мин → 15 сек (−96%); экономия ~300 000 ₽/мес при текущем объёме.',
     metrics: [
-      { label: 'Время отчёта', value: '7 мин → 15 сек', note: '−96%', positive: true },
-      { label: 'Экономия бюджета', value: '~300k ₽/мес', note: 'оценка', positive: true },
+      { label: '', value: 'Время отчета с 7 мин до 15 сек', positive: true },
+      { label: '', value: 'Экономия ~300k ₽/мес', note: 'оценка', positive: true },
     ],
     nda: true,
   },
@@ -300,14 +298,13 @@ function CaseCard({ item, index }: CaseCardProps) {
           </p>
         ) : null}
         {item.metrics && item.metrics.length > 0 ? (
-          <div className="flex flex-wrap gap-3">
+          <div className="flex flex-wrap gap-2">
             {item.metrics.map((metric, metricIndex) => (
               <MetricBadge
                 key={`${item.slug}-metric-${metricIndex}`}
                 value={metric.value}
                 label={metric.label}
-                note={metric.note}
-                positive={metric.positive}
+                direction={metric.positive === false ? 'down' : 'up'}
               />
             ))}
           </div>

--- a/components/primitives/MetricBadge.tsx
+++ b/components/primitives/MetricBadge.tsx
@@ -7,11 +7,9 @@ type MetricBadgeProps = {
   direction?: "up" | "down";
 };
 
-export default function MetricBadge({ value, unit, label, direction }: MetricBadgeProps) {
-  const arrow = direction === "down" ? "↓" : direction === "up" ? "↑" : null;
+export default function MetricBadge({ value, unit, label }: MetricBadgeProps) {
   return (
     <Badge tone="emerald" size="sm" aria-label={label ? `${label}: ${value}${unit ?? ""}` : undefined}>
-      {arrow ? <span aria-hidden>{arrow}</span> : null}
       <strong>
         {value}
         {unit}

--- a/components/primitives/MetricBadge.tsx
+++ b/components/primitives/MetricBadge.tsx
@@ -8,7 +8,7 @@ type MetricBadgeProps = {
 };
 
 export default function MetricBadge({ value, unit, label, direction }: MetricBadgeProps) {
-  const arrow = direction === "down" ? "v" : direction === "up" ? "^" : null;
+  const arrow = direction === "down" ? "↓" : direction === "up" ? "↑" : null;
   return (
     <Badge tone="emerald" size="sm" aria-label={label ? `${label}: ${value}${unit ?? ""}` : undefined}>
       {arrow ? <span aria-hidden>{arrow}</span> : null}

--- a/components/primitives/MetricBadge.tsx
+++ b/components/primitives/MetricBadge.tsx
@@ -1,39 +1,25 @@
-import clsx from '@/lib/clsx';
-import type { BadgeTone } from '@/lib/badge';
+import Badge from "@/components/primitives/Badge";
 
 type MetricBadgeProps = {
   value: string | number;
-  label: string;
-  note?: string;
-  tone?: BadgeTone;
-  positive?: boolean;
+  unit?: string;
+  label?: string;
+  direction?: "up" | "down";
 };
 
-const metricToneClass: Record<BadgeTone, string> = {
-  amber: 'border-amber-500/30 bg-amber-50/70 dark:border-amber-400/30 dark:bg-amber-500/10',
-  sky: 'border-sky-500/30 bg-sky-50/70 dark:border-sky-400/30 dark:bg-sky-500/10',
-  purple: 'border-purple-500/30 bg-purple-50/70 dark:border-purple-400/30 dark:bg-purple-500/10',
-  emerald: 'border-emerald-500/30 bg-emerald-50/70 dark:border-emerald-400/30 dark:bg-emerald-500/10',
-  rose: 'border-rose-500/30 bg-rose-50/70 dark:border-rose-400/30 dark:bg-rose-500/10',
-  slate: 'border-slate-300/40 bg-white/65 dark:border-white/10 dark:bg-white/5',
-};
-
-export default function MetricBadge({ value, label, note, tone, positive }: MetricBadgeProps) {
-  const resolvedTone: BadgeTone = tone ?? (positive === undefined ? 'slate' : positive ? 'emerald' : 'rose');
-
+export default function MetricBadge({ value, unit, label }: MetricBadgeProps) {
   return (
-    <div
-      className={clsx(
-        'flex min-w-[168px] flex-1 basis-[168px] flex-col gap-1 rounded-2xl border px-4 py-3 text-left shadow-sm backdrop-blur-sm',
-        metricToneClass[resolvedTone]
-      )}
-      aria-label={`${label}: ${value}${note ? ` (${note})` : ''}`.trim()}
-    >
-      <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-        {label}
-      </span>
-      <span className="text-lg font-semibold leading-6 text-slate-900 dark:text-white">{value}</span>
-      {note ? <span className="text-xs text-slate-500 dark:text-slate-400">{note}</span> : null}
-    </div>
+    <Badge tone="emerald" size="sm" aria-label={label ? `${label}: ${value}${unit ?? ""}` : undefined}>
+      <strong>
+        {value}
+        {unit}
+      </strong>
+      {label ? (
+        <>
+          &nbsp;
+          <span>{label}</span>
+        </>
+      ) : null}
+    </Badge>
   );
 }

--- a/components/primitives/MetricBadge.tsx
+++ b/components/primitives/MetricBadge.tsx
@@ -1,25 +1,39 @@
-import Badge from "@/components/primitives/Badge";
+import clsx from '@/lib/clsx';
+import type { BadgeTone } from '@/lib/badge';
 
 type MetricBadgeProps = {
   value: string | number;
-  unit?: string;
-  label?: string;
-  direction?: "up" | "down";
+  label: string;
+  note?: string;
+  tone?: BadgeTone;
+  positive?: boolean;
 };
 
-export default function MetricBadge({ value, unit, label }: MetricBadgeProps) {
+const metricToneClass: Record<BadgeTone, string> = {
+  amber: 'border-amber-500/30 bg-amber-50/70 dark:border-amber-400/30 dark:bg-amber-500/10',
+  sky: 'border-sky-500/30 bg-sky-50/70 dark:border-sky-400/30 dark:bg-sky-500/10',
+  purple: 'border-purple-500/30 bg-purple-50/70 dark:border-purple-400/30 dark:bg-purple-500/10',
+  emerald: 'border-emerald-500/30 bg-emerald-50/70 dark:border-emerald-400/30 dark:bg-emerald-500/10',
+  rose: 'border-rose-500/30 bg-rose-50/70 dark:border-rose-400/30 dark:bg-rose-500/10',
+  slate: 'border-slate-300/40 bg-white/65 dark:border-white/10 dark:bg-white/5',
+};
+
+export default function MetricBadge({ value, label, note, tone, positive }: MetricBadgeProps) {
+  const resolvedTone: BadgeTone = tone ?? (positive === undefined ? 'slate' : positive ? 'emerald' : 'rose');
+
   return (
-    <Badge tone="emerald" size="sm" aria-label={label ? `${label}: ${value}${unit ?? ""}` : undefined}>
-      <strong>
-        {value}
-        {unit}
-      </strong>
-      {label ? (
-        <>
-          &nbsp;
-          <span>{label}</span>
-        </>
-      ) : null}
-    </Badge>
+    <div
+      className={clsx(
+        'flex min-w-[168px] flex-1 basis-[168px] flex-col gap-1 rounded-2xl border px-4 py-3 text-left shadow-sm backdrop-blur-sm',
+        metricToneClass[resolvedTone]
+      )}
+      aria-label={`${label}: ${value}${note ? ` (${note})` : ''}`.trim()}
+    >
+      <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        {label}
+      </span>
+      <span className="text-lg font-semibold leading-6 text-slate-900 dark:text-white">{value}</span>
+      {note ? <span className="text-xs text-slate-500 dark:text-slate-400">{note}</span> : null}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace caret and v characters in the metric badge with arrow glyphs to improve display

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67ad95d38832999b0fcb2e5cab53e