### PR TITLE
Fix theme persistence and update nav links

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -7,7 +7,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       attribute="class"          // вешает .dark на <html>
       defaultTheme="system"      // стартуем от системной темы
       enableSystem               // можно выключить, если не нужно
-      storageKey="site-theme"    // ключ в localStorage (опционально)
+      storageKey="theme"         // ключ в localStorage синхронизирован с ThemeScript
       disableTransitionOnChange  // без миганий при переключении
     >
       {children}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import BackButton from '@/components/BackButton'
 import ThemeToggle from '@/components/ThemeToggle'
 import BackgroundToggle from '@/components/BackgroundToggle' // ← вернули
+import { GITHUB_URL, TG_URL } from '@/lib/constants'
 
 type NavProps = {
   backToCases?: boolean
@@ -45,10 +46,10 @@ export default function Nav({ backToCases = false, caseId }: NavProps) {
                 <Link href="/#process" className="opacity-80 hover:opacity-100">
                   Процесс
                 </Link>
-                <Link href="https://github.com" className="opacity-80 hover:opacity-100">
+                <Link href={GITHUB_URL} className="opacity-80 hover:opacity-100">
                   GitHub
                 </Link>
-                <Link href="https://t.me" className="opacity-80 hover:opacity-100">
+                <Link href={TG_URL} className="opacity-80 hover:opacity-100">
                   Telegram
                 </Link>
                 <BackgroundToggle className="hidden md:inline-flex items-center gap-1" aria-label="Переключить фон" />

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,17 +1,67 @@
 "use client";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
+import {
+  useEffect,
+  useState,
+  type ButtonHTMLAttributes,
+  type MouseEvent,
+} from "react";
 
-export default function ThemeToggle() {
+import clsx from "@/lib/clsx";
+
+type ThemeToggleProps = ButtonHTMLAttributes<HTMLButtonElement>;
+
+export default function ThemeToggle({
+  className = "",
+  onClick,
+  "aria-label": ariaLabel,
+  ...rest
+}: ThemeToggleProps) {
   const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+
   useEffect(() => setMounted(true), []);
-  if (!mounted) return null;
+
+  const label = ariaLabel ?? "Переключить тему";
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+    const isDark = resolvedTheme === "dark";
+    setTheme(isDark ? "light" : "dark");
+  };
 
   const isDark = resolvedTheme === "dark";
+
+  const baseClass =
+    "inline-flex h-9 w-9 items-center justify-center rounded-lg border border-transparent bg-[rgb(var(--muted))]/50 text-lg transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--accent))] hover:bg-[rgb(var(--muted))]/70";
+
+  if (!mounted) {
+    return (
+      <button
+        type="button"
+        className={clsx(baseClass, className)}
+        aria-label={label}
+        aria-hidden="true"
+        tabIndex={-1}
+        {...rest}
+      >
+        <span aria-hidden>☀️</span>
+      </button>
+    );
+  }
+
   return (
-    <button onClick={() => setTheme(isDark ? "light" : "dark")} className="...">
-      {isDark ? "🌙" : "☀️"}
+    <button
+      type="button"
+      onClick={handleClick}
+      className={clsx(baseClass, className)}
+      aria-label={label}
+      aria-pressed={isDark}
+      data-state={isDark ? "dark" : "light"}
+      {...rest}
+    >
+      <span aria-hidden>{isDark ? "🌙" : "☀️"}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- align the next-themes storage key with the inline ThemeScript so theme choices persist
- enhance the theme toggle with accessible styling and support for external props
- reuse shared Telegram and GitHub constants in the main navigation

## Testing
- not run (eslint configuration prompt blocks `npm run lint` in CI-less environment)


------
https://chatgpt.com/codex/tasks/task_e_68d692acf2e88329b1955bdbebadce72