### PR TITLE
Adjust brief section styling

### DIFF
--- a/components/BriefForm.tsx
+++ b/components/BriefForm.tsx
@@ -12,9 +12,9 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const TG_RE = /^[a-zA-Z0-9_]{3,32}$/;
 
 const BASE_FIELD_CLASSES =
-  "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-900 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100 dark:placeholder:text-slate-300 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60";
+  "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-500 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100 dark:placeholder:text-slate-300 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60";
 const SELECT_FIELD_CLASSES =
-  "w-full rounded-md border border-slate-300 bg-white px-3 py-2 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-600 dark:bg-slate-800/80 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60 dark:[color-scheme:dark]";
+  "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-600 dark:bg-slate-800/80 dark:text-slate-100 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60 dark:[color-scheme:dark]";
 
 async function compressImageIfNeeded(file: File, maxBytes: number): Promise<File> {
   if (!/^image\/(png|jpeg)$/.test(file.type) || file.size <= maxBytes) return file;
@@ -237,7 +237,7 @@ export default function BriefForm({ maxUploadMB }: Props) {
             name="budget"
             value={budget}
             onChange={(event) => setBudget(event.target.value)}
-            className={`${SELECT_FIELD_CLASSES} text-slate-900 dark:text-slate-100`}
+            className={`${SELECT_FIELD_CLASSES} ${!budget ? "text-slate-500 dark:text-slate-300" : ""}`}
           >
             <option value="" disabled hidden className="bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100">
               Выберите
@@ -259,7 +259,7 @@ export default function BriefForm({ maxUploadMB }: Props) {
             name="deadline"
             value={deadline}
             onChange={(event) => setDeadline(event.target.value)}
-            className={`${SELECT_FIELD_CLASSES} text-slate-900 dark:text-slate-100`}
+            className={`${SELECT_FIELD_CLASSES} ${!deadline ? "text-slate-500 dark:text-slate-300" : ""}`}
           >
             <option value="" disabled hidden className="bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100">
               Выберите
@@ -285,7 +285,7 @@ export default function BriefForm({ maxUploadMB }: Props) {
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            className="inline-flex items-center justify-center rounded-md border border-slate-300/70 bg-slate-200 px-4 py-2 text-sm font-medium text-slate-900 shadow-sm transition hover:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-2 focus:ring-offset-white dark:border-transparent dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200 dark:focus:ring-indigo-400 dark:focus:ring-offset-slate-900"
+            className="inline-flex items-center justify-center rounded-md bg-slate-200 px-4 py-2 text-sm font-medium text-slate-900 transition hover:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-2 focus:ring-offset-white dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200 dark:focus:ring-indigo-400 dark:focus:ring-offset-slate-900"
           >
             Выбрать файл
           </button>

--- a/components/BriefForm.tsx
+++ b/components/BriefForm.tsx
@@ -14,7 +14,7 @@ const TG_RE = /^[a-zA-Z0-9_]{3,32}$/;
 const BASE_FIELD_CLASSES =
   "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-500 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100 dark:placeholder:text-slate-300 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60";
 const SELECT_FIELD_CLASSES =
-  "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-600 dark:bg-slate-800/80 dark:text-slate-100 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60 dark:[color-scheme:dark]";
+  "w-full rounded-md border border-slate-300 bg-white px-3 py-2 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-600 dark:bg-slate-800/80 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60 dark:[color-scheme:dark]";
 
 async function compressImageIfNeeded(file: File, maxBytes: number): Promise<File> {
   if (!/^image\/(png|jpeg)$/.test(file.type) || file.size <= maxBytes) return file;
@@ -237,7 +237,11 @@ export default function BriefForm({ maxUploadMB }: Props) {
             name="budget"
             value={budget}
             onChange={(event) => setBudget(event.target.value)}
-            className={`${SELECT_FIELD_CLASSES} ${!budget ? "text-slate-500 dark:text-slate-300" : ""}`}
+            className={`${SELECT_FIELD_CLASSES} ${
+              budget
+                ? "text-slate-900 dark:text-slate-100"
+                : "text-slate-500 dark:text-slate-300"
+            }`}
           >
             <option value="" disabled hidden className="bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100">
               Выберите
@@ -259,7 +263,11 @@ export default function BriefForm({ maxUploadMB }: Props) {
             name="deadline"
             value={deadline}
             onChange={(event) => setDeadline(event.target.value)}
-            className={`${SELECT_FIELD_CLASSES} ${!deadline ? "text-slate-500 dark:text-slate-300" : ""}`}
+            className={`${SELECT_FIELD_CLASSES} ${
+              deadline
+                ? "text-slate-900 dark:text-slate-100"
+                : "text-slate-500 dark:text-slate-300"
+            }`}
           >
             <option value="" disabled hidden className="bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100">
               Выберите
@@ -285,7 +293,7 @@ export default function BriefForm({ maxUploadMB }: Props) {
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            className="inline-flex items-center justify-center rounded-md bg-slate-200 px-4 py-2 text-sm font-medium text-slate-900 transition hover:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-2 focus:ring-offset-white dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200 dark:focus:ring-indigo-400 dark:focus:ring-offset-slate-900"
+            className="inline-flex items-center justify-center rounded-md border border-slate-300/70 bg-slate-200 px-4 py-2 text-sm font-medium text-slate-900 shadow-sm transition hover:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-2 focus:ring-offset-white dark:border-transparent dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200 dark:focus:ring-indigo-400 dark:focus:ring-offset-slate-900"
           >
             Выбрать файл
           </button>

--- a/components/BriefForm.tsx
+++ b/components/BriefForm.tsx
@@ -12,7 +12,7 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const TG_RE = /^[a-zA-Z0-9_]{3,32}$/;
 
 const BASE_FIELD_CLASSES =
-  "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-500 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100 dark:placeholder:text-slate-300 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60";
+  "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-900 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100 dark:placeholder:text-slate-300 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60";
 const SELECT_FIELD_CLASSES =
   "w-full rounded-md border border-slate-300 bg-white px-3 py-2 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-600 dark:bg-slate-800/80 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60 dark:[color-scheme:dark]";
 

--- a/components/BriefForm.tsx
+++ b/components/BriefForm.tsx
@@ -237,11 +237,7 @@ export default function BriefForm({ maxUploadMB }: Props) {
             name="budget"
             value={budget}
             onChange={(event) => setBudget(event.target.value)}
-            className={`${SELECT_FIELD_CLASSES} ${
-              budget
-                ? "text-slate-900 dark:text-slate-100"
-                : "text-slate-500 dark:text-slate-300"
-            }`}
+            className={`${SELECT_FIELD_CLASSES} text-slate-900 dark:text-slate-100`}
           >
             <option value="" disabled hidden className="bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100">
               Выберите
@@ -263,11 +259,7 @@ export default function BriefForm({ maxUploadMB }: Props) {
             name="deadline"
             value={deadline}
             onChange={(event) => setDeadline(event.target.value)}
-            className={`${SELECT_FIELD_CLASSES} ${
-              deadline
-                ? "text-slate-900 dark:text-slate-100"
-                : "text-slate-500 dark:text-slate-300"
-            }`}
+            className={`${SELECT_FIELD_CLASSES} text-slate-900 dark:text-slate-100`}
           >
             <option value="" disabled hidden className="bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100">
               Выберите

--- a/components/BriefForm.tsx
+++ b/components/BriefForm.tsx
@@ -14,7 +14,7 @@ const TG_RE = /^[a-zA-Z0-9_]{3,32}$/;
 const BASE_FIELD_CLASSES =
   "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-500 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100 dark:placeholder:text-slate-300 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60";
 const SELECT_FIELD_CLASSES =
-  "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60 dark:[color-scheme:dark]";
+  "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm transition focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300/70 dark:border-slate-600 dark:bg-slate-800/80 dark:text-slate-100 dark:focus:border-indigo-400/70 dark:focus:ring-indigo-400/60 dark:[color-scheme:dark]";
 
 async function compressImageIfNeeded(file: File, maxBytes: number): Promise<File> {
   if (!/^image\/(png|jpeg)$/.test(file.type) || file.size <= maxBytes) return file;
@@ -237,13 +237,17 @@ export default function BriefForm({ maxUploadMB }: Props) {
             name="budget"
             value={budget}
             onChange={(event) => setBudget(event.target.value)}
-            className={`${SELECT_FIELD_CLASSES} ${!budget ? "text-slate-500 dark:text-slate-400" : ""}`}
+            className={`${SELECT_FIELD_CLASSES} ${!budget ? "text-slate-500 dark:text-slate-300" : ""}`}
           >
-            <option value="" disabled hidden>
+            <option value="" disabled hidden className="bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100">
               Выберите
             </option>
             {BUDGETS.map((budgetOption) => (
-              <option key={budgetOption} value={budgetOption}>
+              <option
+                key={budgetOption}
+                value={budgetOption}
+                className="bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100"
+              >
                 {budgetOption}
               </option>
             ))}
@@ -255,13 +259,17 @@ export default function BriefForm({ maxUploadMB }: Props) {
             name="deadline"
             value={deadline}
             onChange={(event) => setDeadline(event.target.value)}
-            className={`${SELECT_FIELD_CLASSES} ${!deadline ? "text-slate-500 dark:text-slate-400" : ""}`}
+            className={`${SELECT_FIELD_CLASSES} ${!deadline ? "text-slate-500 dark:text-slate-300" : ""}`}
           >
-            <option value="" disabled hidden>
+            <option value="" disabled hidden className="bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100">
               Выберите
             </option>
             {DEADLINES.map((deadlineOption) => (
-              <option key={deadlineOption} value={deadlineOption}>
+              <option
+                key={deadlineOption}
+                value={deadlineOption}
+                className="bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100"
+              >
                 {deadlineOption}
               </option>
             ))}
@@ -277,7 +285,7 @@ export default function BriefForm({ maxUploadMB }: Props) {
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            className="inline-flex items-center justify-center rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-2 focus:ring-offset-white dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200 dark:focus:ring-indigo-400 dark:focus:ring-offset-slate-900"
+            className="inline-flex items-center justify-center rounded-md bg-slate-200 px-4 py-2 text-sm font-medium text-slate-900 transition hover:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-2 focus:ring-offset-white dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200 dark:focus:ring-indigo-400 dark:focus:ring-offset-slate-900"
           >
             Выбрать файл
           </button>

--- a/components/HomePageView.tsx
+++ b/components/HomePageView.tsx
@@ -41,7 +41,9 @@ export default function HomePageView({ cleanMode }: HomePageViewProps) {
           <Process />
           <Stack />
           <Container id="brief" className="md:scroll-mt-20 py-10 scroll-mt-16">
-            <h2 className="mb-6 text-2xl font-semibold">Оставить бриф проекта</h2>
+            <h2 className="mb-6 text-3xl font-semibold leading-tight md:text-4xl">
+              Оставить бриф проекта
+            </h2>
             {cleanMode ? (
               <p className="max-w-2xl text-base text-slate-600 dark:text-slate-300">
                 Для связи используйте чат площадки.


### PR DESCRIPTION
## Summary
- align the brief section heading size with the Stack heading
- soften the file upload button in light mode and update select styles for consistent placeholder colors and improved dark theme contrast

## Testing
- npm run lint *(fails: `next` CLI not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f7ad7fa08329ad2eeed03ec18e8e